### PR TITLE
Controller port fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3-rc1 (September 1, 2016)
+## 0.3.0 (September 12, 2016)
 
 - The controller API has been overhauled to support a wider range of routing and fault injection rules.
 
@@ -13,6 +13,8 @@
 - NGINX Lua code overhauled to support new rules API format from controller.
 
 - Options for sidecar to proxy, register, and log are now default `false`.
+
+- The default controller port is now 8080 instead of 6379.
 
 - `A8_SERVICE` is now in the form of `<service_name>:<tag1>,<tag2>,...,<tagN>` 
 where `<tagN>` can be a version number or any other tag.  Sidecar will register

--- a/controller/README.md
+++ b/controller/README.md
@@ -44,7 +44,7 @@ The following environment variables are available. All of them are optional.
 
 | Environment Key | Flag Name                   | Description | Default Value |
 |:----------------|:----------------------------|:------------|:--------------|
-| A8_API_PORT | --api_port | API port | 6379 |
+| A8_API_PORT | --api_port | API port | 8080 |
 | A8_CONTROL_TOKEN | --control_token | Controller API authentication token | ABCDEFGHIJKLMNOP |
 | A8_ENCRYPTION_KEY | --encryption_key | secret key | abcdefghijklmnop |
 | A8_DATABASE_TYPE |  --database_type |	database type | memory |

--- a/controller/config/flags.go
+++ b/controller/config/flags.go
@@ -33,7 +33,7 @@ const (
 	requireHTTPSFlag = "require_https"
 )
 
-const apiPort = 6379
+const apiPort = 8080
 
 // Flags command line args for Controller
 var Flags = []cli.Flag{

--- a/examples/kubernetes/controller.yaml
+++ b/examples/kubernetes/controller.yaml
@@ -23,7 +23,7 @@ metadata:
     name: controller
 spec:
   ports:
-  - port: 8080
+  - port: 6080
     targetPort: 8080
     nodePort: 31200
     protocol: TCP

--- a/examples/kubernetes/controller.yaml
+++ b/examples/kubernetes/controller.yaml
@@ -23,7 +23,7 @@ metadata:
     name: controller
 spec:
   ports:
-  - port: 6080
+  - port: 8080
     targetPort: 8080
     nodePort: 31200
     protocol: TCP


### PR DESCRIPTION
Fixes a few issues with https://github.com/amalgam8/amalgam8/commit/d24daf355b7ee06b4d6402b41b837a31e6c996ce for https://github.com/amalgam8/amalgam8/issues/129. Controller now defaults to port 8080 if left unspecified.
