### PR TITLE
Randomly select backend when cookie versions don't match

### DIFF
--- a/sidecar/nginx/lua/amalgam8.lua
+++ b/sidecar/nginx/lua/amalgam8.lua
@@ -317,6 +317,12 @@ local function create_rule(rule, myname, mytags)
       local prev = 0.0
       local unweighted = 0
       for _, b in ipairs(rule.route.backends) do
+         -- add a name to every backend, so that the cookie_version_name is created properly.
+         -- otherwise, we will end up having cookie_version names like -v1, -v2, which will not
+         -- match any backend name stored in the browser's version cookie.
+         if not b.name then
+            b.name = rule.destination
+         end
          if b.weight then
             sum = sum + b.weight
          else

--- a/sidecar/nginx/lua/amalgam8.lua
+++ b/sidecar/nginx/lua/amalgam8.lua
@@ -643,7 +643,9 @@ function Amalgam8:apply_rules()
                break
             end
          end
-      else
+      end
+
+      if not selected_backend then -- cookie_version did not match any backend
          local weight = math.random()
          for _,b in ipairs(selected_route.backends) do --backends are ordered by increasing weight
             if weight < b.weight_order then


### PR DESCRIPTION
This PR fixes a bug in the current 0.3 release of sidecar, where if there is no match with the backend specified in the version cookie, the sidecar issued a HTTP 500 to the client. It also fixes a bug in the way the cookie_Version strings are constructed [if a backend has no name, set the destination as the name]
