### PR TITLE
Remove blank lines and add --anti flag to deploy-bookinfo.sh

### DIFF
--- a/examples/bluemix/deploy-bookinfo.sh
+++ b/examples/bluemix/deploy-bookinfo.sh
@@ -35,21 +35,18 @@ done
 echo "Starting bookinfo productpage microservice (v1)"
 
 bluemix ic group-create --name bookinfo_productpage \
-  --publish 9080 --memory 256 --auto \
+  --publish 9080 --memory 256 --auto --anti \
   --min 1 --max 2 --desired 1 \
   --env A8_REGISTRY_URL=$REGISTRY_URL \
   --env A8_REGISTRY_POLL=5s \
-
   --env A8_CONTROLLER_URL=$CONTROLLER_URL \
   --env A8_CONTROLLER_POLL=5s \
-
   --env A8_SERVICE=productpage:v1 \
   --env A8_ENDPOINT_PORT=9080 \
   --env A8_ENDPOINT_TYPE=http \
-
   --env A8_REGISTER=true \
   --env A8_PROXY=true \
-  ${BLUEMIX_REGISTRY_HOST}/${BLUEMIX_REGISTRY_NAMESPACE}/${PRODUCTPAGE_IMAGE}:v1
+  ${BLUEMIX_REGISTRY_HOST}/${BLUEMIX_REGISTRY_NAMESPACE}/${PRODUCTPAGE_IMAGE}
 
 #################################################################################
 # Start the details microservice instances
@@ -58,13 +55,12 @@ bluemix ic group-create --name bookinfo_productpage \
 echo "Starting bookinfo details microservice (v1)"
 
 bluemix ic group-create --name bookinfo_details \
-  --publish 9080 --memory 256 --auto \
+  --publish 9080 --memory 256 --auto --anti \
   --min 1 --max 2 --desired 1 \
   --env A8_REGISTRY_URL=$REGISTRY_URL \
   --env A8_SERVICE=details:v1 \
   --env A8_ENDPOINT_PORT=9080 \
   --env A8_ENDPOINT_TYPE=http \
-
   --env A8_REGISTER=true \
   ${BLUEMIX_REGISTRY_HOST}/${BLUEMIX_REGISTRY_NAMESPACE}/${DETAILS_IMAGE}
 
@@ -75,14 +71,12 @@ bluemix ic group-create --name bookinfo_details \
 echo "Starting bookinfo ratings microservice (v1)"
 
 bluemix ic group-create --name bookinfo_ratings \
-  --publish 9080 --memory 256 --auto \
+  --publish 9080 --memory 256 --auto --anti \
   --min 1 --max 2 --desired 1 \
   --env A8_REGISTRY_URL=$REGISTRY_URL \
-
   --env A8_SERVICE=ratings:v1 \
   --env A8_ENDPOINT_PORT=9080 \
   --env A8_ENDPOINT_TYPE=http \
-
   --env A8_REGISTER=true \
   ${BLUEMIX_REGISTRY_HOST}/${BLUEMIX_REGISTRY_NAMESPACE}/${RATINGS_IMAGE}
 
@@ -93,18 +87,15 @@ bluemix ic group-create --name bookinfo_ratings \
 echo "Starting bookinfo reviews microservice (v1)"
 
 bluemix ic group-create --name bookinfo_reviews1 \
-  --publish 9080 --memory 256 --auto \
+  --publish 9080 --memory 256 --auto --anti \
   --min 1 --max 2 --desired 1 \
   --env A8_REGISTRY_URL=$REGISTRY_URL \
   --env A8_REGISTRY_POLL=5s \
-
   --env A8_CONTROLLER_URL=$CONTROLLER_URL \
   --env A8_CONTROLLER_POLL=5s \
-
   --env A8_SERVICE=reviews:v1 \
   --env A8_ENDPOINT_PORT=9080 \
   --env A8_ENDPOINT_TYPE=http \
-
   --env A8_REGISTER=true \
   --env A8_PROXY=true \
   ${BLUEMIX_REGISTRY_HOST}/${BLUEMIX_REGISTRY_NAMESPACE}/${REVIEWS_V1_IMAGE}
@@ -112,18 +103,15 @@ bluemix ic group-create --name bookinfo_reviews1 \
 echo "Starting bookinfo reviews microservice (v2)"
 
 bluemix ic group-create --name bookinfo_reviews2 \
-  --publish 9080 --memory 256 --auto \
+  --publish 9080 --memory 256 --auto --anti \
   --min 1 --max 2 --desired 1 \
   --env A8_REGISTRY_URL=$REGISTRY_URL \
   --env A8_REGISTRY_POLL=5s \
-
   --env A8_CONTROLLER_URL=$CONTROLLER_URL \
   --env A8_CONTROLLER_POLL=5s \
-
   --env A8_SERVICE=reviews:v2 \
   --env A8_ENDPOINT_PORT=9080 \
   --env A8_ENDPOINT_TYPE=http \
-
   --env A8_REGISTER=true \
   --env A8_PROXY=true \
   ${BLUEMIX_REGISTRY_HOST}/${BLUEMIX_REGISTRY_NAMESPACE}/${REVIEWS_V2_IMAGE}
@@ -131,18 +119,15 @@ bluemix ic group-create --name bookinfo_reviews2 \
 echo "Starting bookinfo reviews microservice (v3)"
 
 bluemix ic group-create --name bookinfo_reviews3 \
-  --publish 9080 --memory 256 --auto \
+  --publish 9080 --memory 256 --auto --anti \
   --min 1 --max 2 --desired 1 \
   --env A8_REGISTRY_URL=$REGISTRY_URL \
   --env A8_REGISTRY_POLL=5s \
-
   --env A8_CONTROLLER_URL=$CONTROLLER_URL \
   --env A8_CONTROLLER_POLL=5s \
-
   --env A8_SERVICE=reviews:v3 \
   --env A8_ENDPOINT_PORT=9080 \
   --env A8_ENDPOINT_TYPE=http \
-
   --env A8_REGISTER=true \
   --env A8_PROXY=true \
   ${BLUEMIX_REGISTRY_HOST}/${BLUEMIX_REGISTRY_NAMESPACE}/${REVIEWS_V3_IMAGE}
@@ -154,18 +139,15 @@ bluemix ic group-create --name bookinfo_reviews3 \
 echo "Starting bookinfo gateway"
 
 bluemix ic group-create --name bookinfo_gateway \
-  --publish 6379 --memory 256 --auto \
+  --publish 6379 --memory 256 --auto --anti \
   --min 1 --max 2 --desired 1 \
   --hostname $BOOKINFO_HOSTNAME \
   --domain $ROUTES_DOMAIN \
   --env A8_REGISTRY_URL=$REGISTRY_URL \
   --env A8_REGISTRY_POLL=5s \
-
   --env A8_CONTROLLER_URL=$CONTROLLER_URL \
   --env A8_CONTROLLER_POLL=5s \
-
   --env A8_SERVICE=gateway \
-
   --env A8_PROXY=true \
   ${BLUEMIX_REGISTRY_HOST}/${BLUEMIX_REGISTRY_NAMESPACE}/$GATEWAY_IMAGE
 


### PR DESCRIPTION
The deploy to Bluemix was failing when there were empty lines in the "bluemix ic group-create" command. 
Remove the image tag from line 52 because it was already included in the variable.
Added the "--anti" flag (anti-affinity) as a best practice. This does require the latest version of the bluemix cli to be installed.
