### PR TITLE
Update minimum version for Bluemix CLI

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -418,7 +418,7 @@ on IBM Bluemix, follow the instructions below. If you are not a Bluemix user, yo
 
     Once inside the vagrant box, install the following additional dependencies:
     [CF CLI 6.12.0 or later](https://github.com/cloudfoundry/cli/releases),
-    [Bluemix CLI 0.3.3 or later](https://clis.ng.bluemix.net/),
+    [Bluemix CLI 0.4.1 or later](https://clis.ng.bluemix.net/),
 
 1. Switch to the Amalgam8 examples folder
 


### PR DESCRIPTION
With the addition of `--anti` flag to `bluemix ic group-create` command (#275), we now require Bluemix CLI version 0.4.1 and up.
