### PR TITLE
Use python official images for examples

### DIFF
--- a/examples/apps/bookinfo/productpage/Dockerfile
+++ b/examples/apps/bookinfo/productpage/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM jfloff/alpine-python:2.7-onbuild
+FROM python:2-onbuild
 
 RUN mkdir -p /opt/microservices
 COPY . /opt/microservices/

--- a/examples/apps/bookinfo/ratings/Dockerfile
+++ b/examples/apps/bookinfo/ratings/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM jfloff/alpine-python:2.7-onbuild
+FROM python:2-onbuild
 
 RUN mkdir -p /opt/microservices
 COPY . /opt/microservices/

--- a/examples/apps/helloworld/Dockerfile
+++ b/examples/apps/helloworld/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM jfloff/alpine-python:2.7-onbuild
+FROM python:2-onbuild
 
 RUN mkdir -p /opt/microservices
 ADD app.py /opt/microservices/


### PR DESCRIPTION
The jfloff/python docker images have changed and are no longer working with the examples.
This change uses the official python onbuild image from https://hub.docker.com/_/python/

Signed-off-by: Colin Thorne colin_thorne@uk.ibm.com
