### PR TITLE
Nginx: Support service urls without requiring a trailing slash

### DIFF
--- a/sidecar/nginx/conf/amalgam8-rules.conf
+++ b/sidecar/nginx/conf/amalgam8-rules.conf
@@ -22,7 +22,7 @@ proxy_set_header Host $a8_upstream_host;
 #
 # For more information, see:
 # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass
-proxy_pass $a8_service_type://a8_upstreams/$reqpath$is_args$args;
+proxy_pass $a8_service_type://a8_upstreams$reqpath$is_args$args;
 
 # By default, the service name is stripped from the URL before making the upstream call. To retain the
 # service name in the URL, use the following proxy_pass directive instead of the above:

--- a/sidecar/nginx/conf/amalgam8-services.conf
+++ b/sidecar/nginx/conf/amalgam8-services.conf
@@ -16,7 +16,7 @@ server {
        #ssl_certificate /path/to/cert;
        #ssl_certificate_key /path/to/key;
 
-       location ~ ^/(?<service_name>.*?)/(?<reqpath>.*) {
+       location ~ ^/(?<service_name>.*?)(?<reqpath>/(.*))?$ {
          include /etc/nginx/amalgam8-rules.conf;
          # Add proxy SSL verification directives here:
          # proxy_ssl_trusted_certificate /path/to/trusted_ca_cert_list.crt;


### PR DESCRIPTION
fixes #260 
