### PR TITLE
cli for debugging sidecar state. 

### DIFF
--- a/sidecar/api/debug.go
+++ b/sidecar/api/debug.go
@@ -1,0 +1,66 @@
+// Copyright 2016 IBM Corporation
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package api
+
+import (
+	"net/http"
+
+	"github.com/amalgam8/amalgam8/controller/rules"
+	"github.com/amalgam8/amalgam8/registry/client"
+	"github.com/amalgam8/amalgam8/sidecar/proxy"
+	"github.com/ant0ine/go-json-rest/rest"
+)
+
+// DebugAPI handles debugging API calls to sidecar for checking state
+type DebugAPI struct {
+	nginxProxy proxy.NGINXProxy
+}
+
+// NewDebugAPI creates struct
+func NewDebugAPI(nginxProxy proxy.NGINXProxy) *DebugAPI {
+	return &DebugAPI{
+		nginxProxy: nginxProxy,
+	}
+}
+
+// Routes for health check API
+func (d *DebugAPI) Routes(middlewares ...rest.Middleware) []*rest.Route {
+	routes := []*rest.Route{
+		rest.Get("/state", d.checkState),
+	}
+
+	for _, route := range routes {
+		route.Func = rest.WrapMiddlewares(middlewares, route.Func)
+	}
+	return routes
+}
+
+// GetHealth performs health check on controller and dependencies
+func (d *DebugAPI) checkState(w rest.ResponseWriter, req *rest.Request) {
+
+	cachedInstances, cachedRules := d.nginxProxy.GetState()
+
+	state := struct {
+		Instances []client.ServiceInstance `json:"instances"`
+		Rules     []rules.Rule             `json:"rules"`
+	}{
+		Instances: cachedInstances,
+		Rules:     cachedRules,
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.WriteJson(&state)
+
+}

--- a/sidecar/api/debug.go
+++ b/sidecar/api/debug.go
@@ -35,7 +35,7 @@ func NewDebugAPI(nginxProxy proxy.NGINXProxy) *DebugAPI {
 	}
 }
 
-// Routes for health check API
+// Routes for debug API
 func (d *DebugAPI) Routes(middlewares ...rest.Middleware) []*rest.Route {
 	routes := []*rest.Route{
 		rest.Get("/state", d.checkState),
@@ -47,7 +47,8 @@ func (d *DebugAPI) Routes(middlewares ...rest.Middleware) []*rest.Route {
 	return routes
 }
 
-// GetHealth performs health check on controller and dependencies
+// checkState returns the cached rules from controller and cached instances
+// from registry stored in sidecar memory
 func (d *DebugAPI) checkState(w rest.ResponseWriter, req *rest.Request) {
 
 	cachedInstances, cachedRules := d.nginxProxy.GetState()

--- a/sidecar/config/config.go
+++ b/sidecar/config/config.go
@@ -85,6 +85,8 @@ type Config struct {
 	LogstashServer string `yaml:"logstash_server"`
 
 	LogLevel string `yaml:"log_level"`
+
+	Debug string `yaml:"debug"`
 }
 
 // New creates a new Config object from the given commandline flags, environment variables, and configuration file context.
@@ -180,6 +182,7 @@ func (c *Config) loadFromContext(context *cli.Context) error {
 	loadFromContextIfSet(&c.Log, logFlag)
 	loadFromContextIfSet(&c.LogstashServer, logstashServerFlag)
 	loadFromContextIfSet(&c.LogLevel, logLevelFlag)
+	loadFromContextIfSet(&c.Debug, debugFlag)
 
 	if context.IsSet(serviceFlag) {
 		name, tags := parseServiceNameAndTags(context.String(serviceFlag))

--- a/sidecar/config/config.go
+++ b/sidecar/config/config.go
@@ -86,7 +86,7 @@ type Config struct {
 
 	LogLevel string `yaml:"log_level"`
 
-	Debug string `yaml:"debug"`
+	Debug string
 }
 
 // New creates a new Config object from the given commandline flags, environment variables, and configuration file context.

--- a/sidecar/config/flags.go
+++ b/sidecar/config/flags.go
@@ -40,10 +40,15 @@ const (
 	logFlag             = "log"
 	logstashServerFlag  = "logstash_server"
 	logLevelFlag        = "log_level"
+	debugFlag           = "debug"
 )
 
 // Flags is the set of supported flags
 var Flags = []cli.Flag{
+	cli.StringFlag{
+		Name:  debugFlag,
+		Usage: "Check current sidecar state via CLI command",
+	},
 	cli.StringFlag{
 		Name:   configFlag,
 		EnvVar: envVar(configFlag),

--- a/sidecar/proxy/nginxproxy.go
+++ b/sidecar/proxy/nginxproxy.go
@@ -28,6 +28,7 @@ import (
 type NGINXProxy interface {
 	monitor.ControllerListener
 	monitor.RegistryListener
+	GetState() ([]client.ServiceInstance, []rules.Rule)
 }
 
 type nginxProxy struct {
@@ -67,4 +68,11 @@ func (n *nginxProxy) RuleChange(rules []rules.Rule) error {
 func (n *nginxProxy) updateNGINX() error {
 	logrus.Debug("Updating NGINX")
 	return n.nginx.Update(n.instances, n.rules)
+}
+
+func (n *nginxProxy) GetState() ([]client.ServiceInstance, []rules.Rule) {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+
+	return n.instances, n.rules
 }

--- a/sidecar/sidecar.go
+++ b/sidecar/sidecar.go
@@ -23,14 +23,22 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/urfave/cli"
 
+	"encoding/json"
+	"net/http"
+	"time"
+
 	controllerclient "github.com/amalgam8/amalgam8/controller/client"
+	"github.com/amalgam8/amalgam8/controller/rules"
 	registryclient "github.com/amalgam8/amalgam8/registry/client"
+	"github.com/amalgam8/amalgam8/sidecar/api"
 	"github.com/amalgam8/amalgam8/sidecar/config"
 	"github.com/amalgam8/amalgam8/sidecar/proxy"
 	"github.com/amalgam8/amalgam8/sidecar/proxy/monitor"
 	"github.com/amalgam8/amalgam8/sidecar/proxy/nginx"
 	"github.com/amalgam8/amalgam8/sidecar/register"
 	"github.com/amalgam8/amalgam8/sidecar/supervisor"
+	"github.com/amalgam8/registry/client"
+	"github.com/ant0ine/go-json-rest/rest"
 )
 
 // Main is the entrypoint for the sidecar when running as an executable
@@ -64,6 +72,11 @@ func sidecarCommand(context *cli.Context) error {
 // Run the sidecar with the given configuration
 func Run(conf config.Config) error {
 	var err error
+
+	if conf.Debug != "" {
+		cliCommand(conf.Debug)
+		return nil
+	}
 
 	if err = conf.Validate(); err != nil {
 		logrus.WithError(err).Error("Validation of config failed")
@@ -220,5 +233,126 @@ func startProxy(conf *config.Config) error {
 		}
 	}()
 
+	debugger := api.NewDebugAPI(nginxProxy)
+
+	a := rest.NewApi()
+	a.Use(
+		&rest.TimerMiddleware{},
+		&rest.RecorderMiddleware{},
+		&rest.RecoverMiddleware{
+			EnableResponseStackTrace: false,
+		},
+		&rest.ContentTypeCheckerMiddleware{},
+		//&middleware.RequestIDMiddleware{},
+		//&middleware.LoggingMiddleware{},
+		//middleware.NewRequireHTTPS(middleware.CheckRequest{
+		//	IsSecure: middleware.IsUsingSecureConnection,
+		//	Disabled: !conf.RequireHTTPS,
+		//}),
+	)
+
+	routes := debugger.Routes()
+	router, err := rest.MakeRouter(
+		routes...,
+	)
+	if err != nil {
+		logrus.WithError(err).Error("Could not start API server")
+		return err
+	}
+	a.SetApp(router)
+
+	go func() {
+		http.ListenAndServe(fmt.Sprintf(":%v", 6116), a.MakeHandler())
+	}()
+
 	return nil
+}
+
+// Instance TODO
+type Instance struct {
+	Tags string `json:"tags"`
+	Type string `json:"type"`
+	Host string `json:"host"`
+	Port int    `json:"port"`
+}
+
+// NGINXState nginx cached lua state
+type NGINXState struct {
+	Routes    map[string][]rules.Rule `json:"routes"`
+	Instances map[string][]Instance   `json:"instances"`
+	Actions   map[string][]rules.Rule `json:"actions"`
+}
+
+func cliCommand(command string) {
+
+	switch command {
+	case "show-state":
+		httpClient := http.Client{
+			Timeout: time.Second * 10,
+		}
+		req, err := http.NewRequest("GET", "http://localhost:6116/state", nil)
+		if err != nil {
+			fmt.Println("Error occurred building the request:", err.Error())
+			return
+		}
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			fmt.Println("Error occurred sending the request:", err.Error())
+			return
+		}
+
+		respBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			fmt.Println("Error occurred reading response body:", err.Error())
+			return
+		}
+
+		sidecarstate := struct {
+			Instances []client.ServiceInstance `json:"instances"`
+			Rules     []rules.Rule             `json:"rules"`
+		}{}
+
+		err = json.Unmarshal(respBytes, &sidecarstate)
+		if err != nil {
+			fmt.Println("Error occurred loading JSON response:", err.Error())
+			return
+		}
+
+		req, err = http.NewRequest("GET", "http://localhost:5813/a8-admin", nil)
+		if err != nil {
+			fmt.Println("Error occurred building the request:", err.Error())
+			return
+		}
+
+		resp, err = httpClient.Do(req)
+		if err != nil {
+			fmt.Println("Error occurred sending the request:", err.Error())
+			return
+		}
+
+		respBytes, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			fmt.Println("Error occurred reading response body:", err.Error())
+			return
+		}
+
+		nginxstate := NGINXState{}
+
+		err = json.Unmarshal(respBytes, &nginxstate)
+		if err != nil {
+			fmt.Println("Error occurred loading JSON response:", err.Error())
+			return
+		}
+
+		sidecarBytes, _ := json.MarshalIndent(&sidecarstate, "", "   ")
+		nginxBytes, _ := json.MarshalIndent(&nginxstate, "", "   ")
+		fmt.Println("\n**************\nSidecar cached info:\n**************")
+		fmt.Println(string(sidecarBytes))
+		fmt.Println("\n**************\nNginx cached state:\n**************")
+		fmt.Println(string(nginxBytes))
+
+	default:
+		fmt.Println("Unrecognized command: ", command)
+	}
 }

--- a/sidecar/sidecar.go
+++ b/sidecar/sidecar.go
@@ -37,7 +37,6 @@ import (
 	"github.com/amalgam8/amalgam8/sidecar/proxy/nginx"
 	"github.com/amalgam8/amalgam8/sidecar/register"
 	"github.com/amalgam8/amalgam8/sidecar/supervisor"
-	"github.com/amalgam8/registry/client"
 	"github.com/ant0ine/go-json-rest/rest"
 )
 
@@ -309,8 +308,8 @@ func cliCommand(command string) {
 		}
 
 		sidecarstate := struct {
-			Instances []client.ServiceInstance `json:"instances"`
-			Rules     []rules.Rule             `json:"rules"`
+			Instances []registryclient.ServiceInstance `json:"instances"`
+			Rules     []rules.Rule                     `json:"rules"`
 		}{}
 
 		err = json.Unmarshal(respBytes, &sidecarstate)
@@ -347,7 +346,7 @@ func cliCommand(command string) {
 
 		sidecarBytes, _ := json.MarshalIndent(&sidecarstate, "", "   ")
 		nginxBytes, _ := json.MarshalIndent(&nginxstate, "", "   ")
-		fmt.Println("\n**************\nSidecar cached info:\n**************")
+		fmt.Println("\n**************\nSidecar cached state:\n**************")
 		fmt.Println(string(sidecarBytes))
 		fmt.Println("\n**************\nNginx cached state:\n**************")
 		fmt.Println(string(nginxBytes))


### PR DESCRIPTION
shows sidecar cached data and lua cached data

example usage (docker exec -it gateway sh):
a8sidecar --debug show-state
