### PR TITLE
build sidecar version of examples without alpine

### DIFF
--- a/examples/apps/bookinfo/build-services.sh
+++ b/examples/apps/bookinfo/build-services.sh
@@ -20,7 +20,7 @@ SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 pushd $SCRIPTDIR/productpage
   docker build -t amalgam8/a8-examples-bookinfo-productpage:v1 .
-  docker build -t amalgam8/a8-examples-bookinfo-productpage-sidecar:v1-alpine -f Dockerfile.sidecar .
+  docker build -t amalgam8/a8-examples-bookinfo-productpage-sidecar:v1 -f Dockerfile.sidecar .
 popd
 
 pushd $SCRIPTDIR/details
@@ -46,5 +46,5 @@ popd
 
 pushd $SCRIPTDIR/ratings
   docker build -t amalgam8/a8-examples-bookinfo-ratings:v1 .
-  docker build -t amalgam8/a8-examples-bookinfo-ratings-sidecar:v1-alpine -f Dockerfile.sidecar .
+  docker build -t amalgam8/a8-examples-bookinfo-ratings-sidecar:v1 -f Dockerfile.sidecar .
 popd

--- a/examples/apps/helloworld/build-services.sh
+++ b/examples/apps/helloworld/build-services.sh
@@ -25,5 +25,5 @@ SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 docker build -t amalgam8/a8-examples-helloworld:v1 $SCRIPTDIR
 docker build -t amalgam8/a8-examples-helloworld:v2 $SCRIPTDIR
 
-docker build -t amalgam8/a8-examples-helloworld-sidecar:v1-alpine -f $SCRIPTDIR/Dockerfile.sidecar $SCRIPTDIR
-docker build -t amalgam8/a8-examples-helloworld-sidecar:v2-alpine -f $SCRIPTDIR/Dockerfile.sidecar $SCRIPTDIR
+docker build -t amalgam8/a8-examples-helloworld-sidecar:v1 -f $SCRIPTDIR/Dockerfile.sidecar $SCRIPTDIR
+docker build -t amalgam8/a8-examples-helloworld-sidecar:v2 -f $SCRIPTDIR/Dockerfile.sidecar $SCRIPTDIR


### PR DESCRIPTION
all python images are based on python-2, which is not alpine based. Removing v1-alpine from example build scripts.
