### PR TITLE
Update to Golang 1.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 
 # Go versions to build with
 go:
-    - 1.6.3
+    - 1.7.1
 
 env:
     # Platforms to build for

--- a/devel/README.md
+++ b/devel/README.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-* [Go](http://golang.org/) version 1.6.3
+* [Go](http://golang.org/) version 1.7.1
 * [Docker](https://docs.docker.com/engine/installation/) 1.10 or later
 * [Docker Compose](https://docs.docker.com/compose/install/)  1.5.1 or later
 * Python 2.7 with pip

--- a/devel/Vagrantfile
+++ b/devel/Vagrantfile
@@ -40,8 +40,8 @@ sudo chmod +x /usr/local/bin/docker-compose
 
 # Install golang
 cd /tmp
-curl -O https://storage.googleapis.com/golang/go1.6.3.linux-amd64.tar.gz
-tar -C /usr/local -xzf go1.6.3.linux-amd64.tar.gz
+curl -O https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz
+tar -C /usr/local -xzf go1.7.1.linux-amd64.tar.gz
 if ! grep -Fq "/home/vagrant/sandbox" /home/vagrant/.profile; then
 	echo 'export GOPATH=/home/vagrant/sandbox' >> /home/vagrant/.profile
 fi


### PR DESCRIPTION
Given that our previous issues with Go 1.7 has already been resolved (see #266), we can move forward with updating Go version. Note that #341 brings in the `net/context`, which in Go 1.7 has been added to the standard library.
