### PR TITLE
Fix registration agent to synchronously deregister when stopped

### DIFF
--- a/sidecar/register/registration.go
+++ b/sidecar/register/registration.go
@@ -30,7 +30,7 @@ const DefaultReregistrationDelay = time.Duration(5) * time.Second
 
 // RegistrationConfig options
 type RegistrationConfig struct {
-	Client          client.Client
+	Client          client.Registry
 	ServiceInstance *client.ServiceInstance
 }
 

--- a/sidecar/register/registration_test.go
+++ b/sidecar/register/registration_test.go
@@ -1,0 +1,126 @@
+// Copyright 2016 IBM Corporation
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package register
+
+import (
+	"github.com/amalgam8/amalgam8/registry/client"
+
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Registration agent", func() {
+	mockClient := &mockRegistryClient{}
+	config := RegistrationConfig{
+		ServiceInstance: &client.ServiceInstance{
+			ServiceName: "test_service",
+			Endpoint: client.ServiceEndpoint{
+				Type:  "http",
+				Value: "http://172.17.0.10:8080",
+			},
+			TTL: 1,
+		},
+		Client: mockClient,
+	}
+
+	var agent *RegistrationAgent
+	var err error
+
+	BeforeEach(func() {
+		mockClient.Reset()
+
+		agent, err = NewRegistrationAgent(config)
+		Expect(err).To((BeNil()))
+
+		agent.Start()
+	})
+
+	Context("When registration agent is started", func() {
+
+		It("Registers the service with the registry", func() {
+			// Avoid race condition on registration
+			time.Sleep(100 * time.Millisecond)
+
+			Expect(mockClient.registered).To(BeTrue())
+		})
+
+		It("Continuously renews the registration", func() {
+			// Avoid race condition on registration
+			time.Sleep(100 * time.Millisecond)
+
+			ttl := time.Duration(config.ServiceInstance.TTL) * time.Second
+			for i := 0; i < 3; i++ {
+				// Assert that last heartbeat took place at most <TTL> ago
+				Expect(mockClient.lastHeartbeat).To(BeTemporally("~", time.Now(), ttl))
+				time.Sleep(ttl)
+			}
+		})
+	})
+
+	Context("When registration agent is stopped", func() {
+
+		BeforeEach(func() {
+			agent.Stop()
+		})
+
+		It("Deregisters the service with the registry", func() {
+			Expect(mockClient.registered).To(BeFalse())
+		})
+
+		It("Can be started again", func() {
+			agent.Start()
+			time.Sleep(250 * time.Millisecond)
+
+			Expect(mockClient.registered).To(BeTrue())
+		})
+	})
+
+})
+
+type mockRegistryClient struct {
+	registered    bool
+	lastHeartbeat time.Time
+}
+
+func (c *mockRegistryClient) Register(instance *client.ServiceInstance) (*client.ServiceInstance, error) {
+	c.registered = true
+	c.lastHeartbeat = time.Now()
+	return &client.ServiceInstance{
+		ID:            "1234567890",
+		ServiceName:   instance.ServiceName,
+		Endpoint:      instance.Endpoint,
+		Status:        instance.Status,
+		Tags:          instance.Tags,
+		Metadata:      instance.Metadata,
+		TTL:           instance.TTL,
+		LastHeartbeat: c.lastHeartbeat,
+	}, nil
+}
+
+func (c *mockRegistryClient) Deregister(id string) error {
+	c.registered = false
+	return nil
+}
+
+func (c *mockRegistryClient) Renew(id string) error {
+	c.lastHeartbeat = time.Now()
+	return nil
+}
+
+func (c *mockRegistryClient) Reset() {
+	c.registered = false
+}

--- a/sidecar/sidecar.go
+++ b/sidecar/sidecar.go
@@ -123,8 +123,6 @@ func Run(conf config.Config) error {
 	}
 
 	if conf.Register {
-		logrus.Info("Registering")
-
 		registryClient, err := registryclient.New(registryclient.Config{
 			URL:       conf.Registry.URL,
 			AuthToken: conf.Registry.Token,


### PR DESCRIPTION
This PR fixes a bug in the sidecar shutdown logic where the service deregistration attempt is performed asynchronously with a background goroutine, while the main goroutine already exits. This causes the deregistration goroutine to exit as well, most likely before it managed to actually deregister.

Additionally, this PR adds unit tests for the basic regisration agent functions, as well as improved logging (which partially resolves issue #339).
