### PR TITLE
Test framework fixes to enable integration tests on mac

### DIFF
--- a/devel/README.md
+++ b/devel/README.md
@@ -39,7 +39,7 @@ Registry and the Amalgam8 Sidecar, run the following commands:
 
 ```bash
 cd $GOPATH/src/github.com/amalgam8/amalgam8
-make build dockerize
+GOOS=linux GOARCH=amd64 make build dockerize
 ```
 
 You should now have three docker images, namely `a8-controller:latest`,
@@ -64,10 +64,33 @@ The Go-based components can also be run outside of a docker container as Go
 binaries.  While this is not recommended for production, it can be useful
 for development or easier integration with your local Go tools.
 
-The `make build` command builds binaries for the controller, registry and
-the sidecar. The binaries can be found under the `bin` folder under the
+The `GOOS=linux GOARCH=amd64 make build` command builds linux binaries for
+the controller, registry and the sidecar irrespective of the host OS and architecture.
+The binaries can be found under the `bin` folder under the
 repository root directory (`$GOPATH/src/github.com/amalgam8/amalgam8`).
 
+## Running Local Integration Tests
+
+End-to-end integration tests can be run using the following make target:
+
+```bash
+make test.integration
+```
+
+The above command would run the integration test for both Docker Compose
+and Kubernetes. To disable testing on kubernetes (i.e. test with just
+Docker compose), run
+
+```bash
+A8_TEST_K8S=false make test.integration
+```
+
+Similarlu, to disable testing with Docker Compose (i.e. test with just
+Kubernetes), run
+
+```bash
+A8_TEST_DOCKER=false make test.integration
+```
 
 ## Makefile Targets
 

--- a/testing/build_and_run.sh
+++ b/testing/build_and_run.sh
@@ -17,8 +17,21 @@
 set -x
 set -o errexit
 
-SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+if [ -z "$A8_TEST_DOCKER" ]; then
+    A8_TEST_DOCKER="true"
+fi
 
+if [ -z "$A8_TEST_K8S" ]; then
+    A8_TEST_K8S="true"
+fi
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 $SCRIPTDIR/build-scripts/build-amalgam8.sh
-$SCRIPTDIR/docker/test-docker.sh
-$SCRIPTDIR/kubernetes/test-kubernetes.sh
+
+if [ "$A8_TEST_DOCKER" == "true" ]; then
+    $SCRIPTDIR/docker/test-docker.sh
+fi
+
+if [ "$A8_TEST_K8S" == "true" ]; then
+    $SCRIPTDIR/kubernetes/test-kubernetes.sh
+fi

--- a/testing/docker/run-controlplane-docker.sh
+++ b/testing/docker/run-controlplane-docker.sh
@@ -20,7 +20,7 @@ set -x
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 if [ "$1" == "start" ]; then
-    echo "starting Control plane components (ELK stack, registry, and controller)"
+    echo "starting Control plane components (registry, and controller)"
     docker-compose -f $SCRIPTDIR/controlplane.yaml up -d
     echo "waiting for the cluster to initialize.."
 

--- a/testing/test-scripts/demo_script.sh
+++ b/testing/test-scripts/demo_script.sh
@@ -23,11 +23,12 @@ jsondiff() {
     file1=$(jq -S . $1 2> /dev/null) || file1=$(cat $1)
     file2=$(jq -S . $2 2> /dev/null) || file2=$(cat $2)
     
-    # Diff, but ignore whitespace
-    diff -EZb <(echo $file1) <(echo $file2)
+    # Diff, but ignore all whitespace since
+    diff -Ewb <(echo $file1) <(echo $file2)        
 }
 
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
 a8ctl service-list
 sleep 2
 a8ctl rule-clear


### PR DESCRIPTION
This PR fixes some minor issues in the test framework that prevented the integration tests from running on a mac. The notable changes include the use of `-w` flag instead of `-Z` flag to strip whitespaces and environment variable flags to disable docker/kubernetes environments for quick testing.