### PR TITLE
add stream block to nginx.conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,7 @@ release.sidecar:
 		$(BUILDDIR)/opt/a8_lualib \
 		$(BUILDDIR)/opt/openresty_dist \
 		$(BUILDDIR)/etc/nginx \
+		$(BUILDDIR)/etc/nginx/stream \
 		$(BUILDDIR)/usr/bin \
 		$(BUILDDIR)/usr/share/$(SIDECAR_APP_NAME)
 	@cp sidecar/nginx/conf/*.conf $(BUILDDIR)/etc/nginx/

--- a/sidecar/nginx/conf/nginx.conf
+++ b/sidecar/nginx/conf/nginx.conf
@@ -33,5 +33,5 @@ http {
 }
 
 stream {
- include /etc/nginx/conf.d/*.stream.conf;
+ include /etc/nginx/conf.d/stream/*.conf;
 }

--- a/sidecar/nginx/conf/nginx.conf
+++ b/sidecar/nginx/conf/nginx.conf
@@ -26,12 +26,12 @@ http {
   keepalive_requests 10000;
   types_hash_max_size 2048;
 
-  include /etc/nginx/conf.d/*.http.conf;
+  include /etc/nginx/conf.d/*.conf;
 
   access_log  /var/log/nginx/access.log;
   error_log /var/log/nginx/error.log warn;
 }
 
 stream {
- include /etc/nginx/conf.d/*.stream.conf
+ include /etc/nginx/conf.d/*.stream.conf;
 }

--- a/sidecar/nginx/conf/nginx.conf
+++ b/sidecar/nginx/conf/nginx.conf
@@ -26,8 +26,12 @@ http {
   keepalive_requests 10000;
   types_hash_max_size 2048;
 
-  include /etc/nginx/conf.d/*.conf;
+  include /etc/nginx/conf.d/*.http.conf;
 
   access_log  /var/log/nginx/access.log;
   error_log /var/log/nginx/error.log warn;
+}
+
+stream {
+ include /etc/nginx/conf.d/*.stream.conf
 }


### PR DESCRIPTION
This PR addresses issue #402 reported by @greglanthier. Users can include configurations for proxying TCP services as part of their sidecar customization. This is an interim fix until we support generating TCP config files as part of the config reload process.