### PR TITLE
removed overzealous zombie process clean up and switched to dumb-init

### DIFF
--- a/docker/Dockerfile.sidecar.alpine
+++ b/docker/Dockerfile.sidecar.alpine
@@ -12,102 +12,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-# FROM alpine:latest
-
-# RUN mkdir /var/log/nginx
-
-# # Docker Build Arguments
-# ARG RESTY_VERSION="1.9.15.1"
-# ARG RESTY_OPENSSL_VERSION="1.0.2h"
-# ARG RESTY_PCRE_VERSION="8.38"
-# ARG RESTY_J="1"
-# ARG RESTY_CONFIG_OPTIONS="\
-#     --with-file-aio \
-#     --with-http_addition_module \
-#     --with-http_auth_request_module \
-#     --with-http_dav_module \
-#     --with-http_flv_module \
-#     --with-http_geoip_module=dynamic \
-#     --with-http_gunzip_module \
-#     --with-http_gzip_static_module \
-#     --with-http_image_filter_module=dynamic \
-#     --with-http_mp4_module \
-#     --with-http_perl_module=dynamic \
-#     --with-http_random_index_module \
-#     --with-http_realip_module \
-#     --with-http_secure_link_module \
-#     --with-http_slice_module \
-#     --with-http_ssl_module \
-#     --with-http_stub_status_module \
-#     --with-http_sub_module \
-#     --with-http_v2_module \
-#     --with-http_xslt_module=dynamic \
-#     --with-ipv6 \
-#     --with-mail \
-#     --with-mail_ssl_module \
-#     --with-md5-asm \
-#     --with-pcre-jit \
-#     --with-sha1-asm \
-#     --with-stream \
-#     --with-stream_ssl_module \
-#     --with-threads \
-#     --conf-path=/etc/nginx/nginx.conf \
-#     --pid-path=/var/run/nginx.pid \
-#     --user=nginx \
-#     --with-cc-opt='-O3' \
-#     --with-luajit-xcflags='-O3' \
-#     "
-
-# # These are not intended to be user-specified
-# ARG _RESTY_CONFIG_DEPS="--with-openssl=/tmp/openssl-${RESTY_OPENSSL_VERSION} --with-pcre=/tmp/pcre-${RESTY_PCRE_VERSION}"
-
-
-# # 1) Install apk dependencies
-# # 2) Download and untar OpenSSL, PCRE, and OpenResty
-# # 3) Build OpenResty
-# # 4) Cleanup
-
-# RUN \
-#     apk add --no-cache --virtual .build-deps \
-#         build-base \
-#         curl \
-#         gd-dev \
-#         geoip-dev \
-#         libxslt-dev \
-#         linux-headers \
-#         make \
-#         perl-dev \
-#         readline-dev \
-#         zlib-dev \
-#     && apk add --no-cache \
-#         gd \
-#         geoip \
-#         libgcc \
-#         libxslt \
-#         ncurses \
-#         perl \
-#         zlib \
-#     && cd /tmp \
-#     && curl -fSL https://www.openssl.org/source/openssl-${RESTY_OPENSSL_VERSION}.tar.gz -o openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
-#     && tar xzf openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
-#     && curl -fSL https://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-${RESTY_PCRE_VERSION}.tar.gz -o pcre-${RESTY_PCRE_VERSION}.tar.gz \
-#     && tar xzf pcre-${RESTY_PCRE_VERSION}.tar.gz \
-#     && curl -fSL https://openresty.org/download/openresty-${RESTY_VERSION}.tar.gz -o openresty-${RESTY_VERSION}.tar.gz \
-#     && tar xzf openresty-${RESTY_VERSION}.tar.gz \
-#     && cd /tmp/openresty-${RESTY_VERSION} \
-#     && ./configure -j${RESTY_J} ${_RESTY_CONFIG_DEPS} ${RESTY_CONFIG_OPTIONS} \
-#     && make -j${RESTY_J} \
-#     && make -j${RESTY_J} install \
-#     && cd /tmp \
-#     && ln -s /usr/local/openresty/nginx/sbin/nginx /usr/local/bin/nginx \
-#     && rm -rf \
-#         openssl-${RESTY_OPENSSL_VERSION} \
-#         openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
-#         openresty-${RESTY_VERSION}.tar.gz openresty-${RESTY_VERSION} \
-#         pcre-${RESTY_PCRE_VERSION}.tar.gz pcre-${RESTY_PCRE_VERSION} \
-#     && apk del .build-deps
-
-
 FROM openresty/openresty:alpine
 
 RUN apk update && apk add curl
@@ -132,6 +36,9 @@ RUN set -ex \
     && mkdir /lib64 \
     && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 
+RUN apk --no-cache add openssl
+RUN wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64
+RUN chmod +x /usr/bin/dumb-init
 
 ADD sidecar/nginx/lua /opt/a8_lualib
 COPY sidecar/nginx/conf/*.conf /etc/nginx/
@@ -140,6 +47,6 @@ ADD docker/run_filebeat.sh /usr/bin/run_filebeat.sh
 
 ADD bin/a8sidecar /usr/bin/a8sidecar
 
-ENTRYPOINT ["/usr/bin/a8sidecar"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/usr/bin/a8sidecar"]
 
 EXPOSE 6379

--- a/docker/Dockerfile.sidecar.alpine
+++ b/docker/Dockerfile.sidecar.alpine
@@ -36,9 +36,9 @@ RUN set -ex \
     && mkdir /lib64 \
     && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 
-RUN apk --no-cache add openssl
-RUN wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64
-RUN chmod +x /usr/bin/dumb-init
+RUN apk --no-cache add openssl \
+    && wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 \
+    && chmod +x /usr/bin/dumb-init
 
 ADD sidecar/nginx/lua /opt/a8_lualib
 COPY sidecar/nginx/conf/*.conf /etc/nginx/

--- a/docker/Dockerfile.sidecar.ubuntu
+++ b/docker/Dockerfile.sidecar.ubuntu
@@ -32,6 +32,9 @@ RUN set -ex \
     \
     && rm -rf /tmp/filebeat*
 
+RUN curl -sSL -o /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64
+RUN chmod +x /usr/bin/dumb-init
+
 ADD sidecar/nginx/lua /opt/a8_lualib
 COPY sidecar/nginx/conf/*.conf /etc/nginx/
 ADD docker/filebeat.yml /etc/filebeat/filebeat.yml
@@ -39,6 +42,6 @@ ADD docker/run_filebeat.sh /usr/bin/run_filebeat.sh
 
 ADD bin/a8sidecar /usr/bin/a8sidecar
 
-ENTRYPOINT ["/usr/bin/a8sidecar"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/usr/bin/a8sidecar"]
 
 EXPOSE 6379

--- a/docker/Dockerfile.sidecar.ubuntu
+++ b/docker/Dockerfile.sidecar.ubuntu
@@ -32,8 +32,8 @@ RUN set -ex \
     \
     && rm -rf /tmp/filebeat*
 
-RUN curl -sSL -o /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64
-RUN chmod +x /usr/bin/dumb-init
+RUN curl -sSL -o /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 \
+    && chmod +x /usr/bin/dumb-init
 
 ADD sidecar/nginx/lua /opt/a8_lualib
 COPY sidecar/nginx/conf/*.conf /etc/nginx/

--- a/examples/apps/bookinfo/details/Dockerfile.sidecar
+++ b/examples/apps/bookinfo/details/Dockerfile.sidecar
@@ -19,6 +19,6 @@ COPY . /opt/microservices/
 EXPOSE 9080
 WORKDIR /opt/microservices
 
-RUN wget -qO- https://github.com/amalgam8/amalgam8/releases/download/v0.4.2/a8sidecar.sh | sh
+RUN wget -qO- https://github.com/amalgam8/amalgam8/releases/download/v0.4.3/a8sidecar.sh | sh
 
-ENTRYPOINT ["a8sidecar", "ruby", "details.rb", "9080"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "a8sidecar", "ruby", "details.rb", "9080"]

--- a/examples/apps/bookinfo/productpage/Dockerfile.sidecar
+++ b/examples/apps/bookinfo/productpage/Dockerfile.sidecar
@@ -24,10 +24,10 @@ COPY filebeat.yml /etc/filebeat/filebeat.yml
 COPY config.yaml /opt/microservices/config.yaml
 COPY run_filebeat.sh /usr/bin/run_filebeat.sh
 
-RUN wget -qO- https://github.com/amalgam8/amalgam8/releases/download/v0.4.2/a8sidecar.sh | sh
+RUN wget -qO- https://github.com/amalgam8/amalgam8/releases/download/v0.4.3/a8sidecar.sh | sh
 
 COPY . /opt/microservices/
 EXPOSE 9080
 WORKDIR /opt/microservices
 
-ENTRYPOINT ["a8sidecar", "--config", "/opt/microservices/config.yaml"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "a8sidecar", "--config", "/opt/microservices/config.yaml"]

--- a/examples/apps/bookinfo/ratings/Dockerfile.sidecar
+++ b/examples/apps/bookinfo/ratings/Dockerfile.sidecar
@@ -14,8 +14,8 @@
 
 FROM node:4-onbuild
 
-RUN wget -qO- https://github.com/amalgam8/amalgam8/releases/download/v0.4.2/a8sidecar.sh | sh
+RUN wget -qO- https://github.com/amalgam8/amalgam8/releases/download/v0.4.3/a8sidecar.sh | sh
 
 EXPOSE 9080
 
-ENTRYPOINT ["a8sidecar", "node", "ratings.js", "9080"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "a8sidecar", "node", "ratings.js", "9080"]

--- a/examples/apps/bookinfo/reviews/reviews-wlpcfg/Dockerfile.sidecar
+++ b/examples/apps/bookinfo/reviews/reviews-wlpcfg/Dockerfile.sidecar
@@ -24,7 +24,7 @@ COPY filebeat.yml /etc/filebeat/filebeat.yml
 COPY config.yaml /opt/microservices/config.yaml
 COPY run_filebeat.sh /usr/bin/run_filebeat.sh
 
-RUN wget -qO- https://github.com/amalgam8/amalgam8/releases/download/v0.4.2/a8sidecar.sh | sh
+RUN wget -qO- https://github.com/amalgam8/amalgam8/releases/download/v0.4.3/a8sidecar.sh | sh
 
 ENV SERVERDIRNAME reviews
 
@@ -40,4 +40,4 @@ ENV ENABLE_RATINGS ${enable_ratings:-false}
 ENV STAR_COLOR ${star_color:-black}
 ENV PROXY_SERVICE http://127.0.0.1:6379
 
-CMD [ "a8sidecar", "--config", "/opt/microservices/config.yaml" ]
+CMD [ "/usr/bin/dumb-init", "--", "a8sidecar", "--config", "/opt/microservices/config.yaml" ]

--- a/examples/apps/helloworld/Dockerfile.sidecar
+++ b/examples/apps/helloworld/Dockerfile.sidecar
@@ -20,6 +20,6 @@ ADD app.py /opt/microservices/
 EXPOSE 5000
 WORKDIR /opt/microservices
 
-RUN wget -qO- https://github.com/amalgam8/amalgam8/releases/download/v0.4.2/a8sidecar.sh | sh
+RUN wget -qO- https://github.com/amalgam8/amalgam8/releases/download/v0.4.3/a8sidecar.sh | sh
 
-ENTRYPOINT ["a8sidecar", "--config", "/opt/microservices/config.yaml"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "a8sidecar", "--config", "/opt/microservices/config.yaml"]

--- a/scripts/a8sidecar.sh
+++ b/scripts/a8sidecar.sh
@@ -63,3 +63,10 @@ tar -xzf /tmp/a8sidecar-${A8SIDECAR_RELEASE}-linux-amd64.tar.gz -C /
 #Cleanup
 rm -rf ${A8TMP}
 rm /tmp/a8sidecar-${A8SIDECAR_RELEASE}-linux-amd64.tar.gz
+
+if [ $HAVE_WGET -eq 1 ]; then
+    wget -qO /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64
+else
+    curl -sSL -o /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64
+fi
+chmod +x /usr/bin/dumb-init

--- a/testing/apps/details/Dockerfile.sidecar
+++ b/testing/apps/details/Dockerfile.sidecar
@@ -19,4 +19,4 @@ COPY details /opt/microservices/
 
 EXPOSE 9080
 
-ENTRYPOINT ["a8sidecar", "/opt/microservices/details", "9080" ]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "a8sidecar", "/opt/microservices/details", "9080" ]

--- a/testing/apps/details/Dockerfile.sidecar
+++ b/testing/apps/details/Dockerfile.sidecar
@@ -19,4 +19,4 @@ COPY details /opt/microservices/
 
 EXPOSE 9080
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--", "a8sidecar", "/opt/microservices/details", "9080" ]
+CMD ["/opt/microservices/details", "9080" ]

--- a/testing/apps/productpage/Dockerfile.sidecar
+++ b/testing/apps/productpage/Dockerfile.sidecar
@@ -19,4 +19,4 @@ COPY productpage /opt/microservices/
 
 EXPOSE 9080
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--", "a8sidecar", "/opt/microservices/productpage", "9080", "http://localhost:6379"]
+CMD ["/opt/microservices/productpage", "9080", "http://localhost:6379"]

--- a/testing/apps/productpage/Dockerfile.sidecar
+++ b/testing/apps/productpage/Dockerfile.sidecar
@@ -19,4 +19,4 @@ COPY productpage /opt/microservices/
 
 EXPOSE 9080
 
-ENTRYPOINT ["a8sidecar", "/opt/microservices/productpage", "9080", "http://localhost:6379"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "a8sidecar", "/opt/microservices/productpage", "9080", "http://localhost:6379"]

--- a/testing/apps/ratings/Dockerfile.sidecar
+++ b/testing/apps/ratings/Dockerfile.sidecar
@@ -19,4 +19,4 @@ COPY ratings /opt/microservices/
 
 EXPOSE 9080
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--", "a8sidecar", "/opt/microservices/ratings", "9080" ]
+CMD ["/opt/microservices/ratings", "9080" ]

--- a/testing/apps/ratings/Dockerfile.sidecar
+++ b/testing/apps/ratings/Dockerfile.sidecar
@@ -19,4 +19,4 @@ COPY ratings /opt/microservices/
 
 EXPOSE 9080
 
-ENTRYPOINT ["a8sidecar", "/opt/microservices/ratings", "9080" ]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "a8sidecar", "/opt/microservices/ratings", "9080" ]

--- a/testing/apps/reviews/Dockerfile.sidecar
+++ b/testing/apps/reviews/Dockerfile.sidecar
@@ -24,4 +24,4 @@ ENV STAR_COLOR ${star_color:-black}
 
 EXPOSE 9080
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--", "a8sidecar", "/opt/microservices/reviews", "9080", "http://localhost:6379"]
+CMD ["/opt/microservices/reviews", "9080", "http://localhost:6379"]

--- a/testing/apps/reviews/Dockerfile.sidecar
+++ b/testing/apps/reviews/Dockerfile.sidecar
@@ -24,4 +24,4 @@ ENV STAR_COLOR ${star_color:-black}
 
 EXPOSE 9080
 
-ENTRYPOINT ["a8sidecar", "/opt/microservices/reviews", "9080", "http://localhost:6379"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "a8sidecar", "/opt/microservices/reviews", "9080", "http://localhost:6379"]


### PR DESCRIPTION
the current zombie process cleanup was receiving SIGCHLD's for commands started in other parts of the sidecar code (see issue #401 ).  Switched over to use dumb-init as PID to handle zombie process cleanup