### PR TITLE
Support discovery REST API in sidecar agent

### DIFF
--- a/sidecar/config/config.go
+++ b/sidecar/config/config.go
@@ -152,6 +152,8 @@ type Config struct {
 	Commands []Command `yaml:"commands"`
 
 	Debug string
+
+	DiscoveryPort int
 }
 
 // New creates a new Config object from the given commandline flags, environment variables, and configuration file context.
@@ -256,6 +258,7 @@ func (c *Config) loadFromContext(context *cli.Context) error {
 	loadFromContextIfSet(&c.Dnsconfig.Domain, dnsConfigDomainFlag)
 	loadFromContextIfSet(&c.LogLevel, logLevelFlag)
 	loadFromContextIfSet(&c.Debug, debugFlag)
+	loadFromContextIfSet(&c.DiscoveryPort, discoveryPortFlag)
 
 	if context.IsSet(serviceFlag) {
 		name, tags := parseServiceNameAndTags(context.String(serviceFlag))

--- a/sidecar/config/config.go
+++ b/sidecar/config/config.go
@@ -352,7 +352,8 @@ func (c *Config) Validate() error {
 	validators = append(validators,
 		IsInSet("Registry backend", c.Registry.Backend, []string{Amalgam8Backend, KubernetesBackend, EurekaBackend}),
 		IsEmptyOrValidURL("Amalgam8 Registry URL", c.Registry.Amalgam8.URL),
-		IsEmptyOrValidURL("Kubernetes URL", c.Registry.Kubernetes.URL))
+		IsEmptyOrValidURL("Kubernetes URL", c.Registry.Kubernetes.URL),
+		IsInRange("Service Discovery Port", c.DiscoveryPort, 1, 65535))
 	for _, url := range c.Registry.Eureka.URLs {
 		validators = append(validators, IsEmptyOrValidURL("Eureka URL", url))
 	}

--- a/sidecar/config/config_test.go
+++ b/sidecar/config/config_test.go
@@ -454,6 +454,7 @@ registry:
 					Env:    []string{},
 					OnExit: TerminateProcess,
 				}},
+				DiscoveryPort: 6500,
 			}
 		})
 
@@ -483,6 +484,11 @@ registry:
 
 		It("rejects Command with empty command", func() {
 			c.Commands[0].Cmd = []string{}
+			Expect(c.Validate()).To(HaveOccurred())
+		})
+
+		It("rejects DiscoverPort with out of range port", func() {
+			c.DiscoveryPort = 999999
 			Expect(c.Validate()).To(HaveOccurred())
 		})
 	})

--- a/sidecar/config/default.go
+++ b/sidecar/config/default.go
@@ -71,4 +71,6 @@ var DefaultConfig = Config{
 	LogLevel: "info",
 
 	Commands: nil,
+
+	DiscoveryPort: 6500,
 }

--- a/sidecar/config/flags.go
+++ b/sidecar/config/flags.go
@@ -47,6 +47,7 @@ const (
 	dnsConfigPortFlag       = "dns_port"
 	dnsConfigDomainFlag     = "dns_domain"
 	debugFlag               = "debug"
+	discoveryPortFlag       = "discovery_port"
 )
 
 // Flags is the set of supported flags
@@ -175,6 +176,11 @@ var Flags = []cli.Flag{
 		Name:   logLevelFlag,
 		EnvVar: envVar(logLevelFlag),
 		Usage:  "Logging level (debug, info, warn, error, fatal, panic)",
+	},
+	cli.IntFlag{
+		Name:   discoveryPortFlag,
+		EnvVar: envVar(discoveryPortFlag),
+		Usage:  "Service discovery server port number",
 	},
 }
 

--- a/sidecar/register/config.go
+++ b/sidecar/register/config.go
@@ -1,0 +1,25 @@
+// Copyright 2016 IBM Corporation
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package register
+
+import (
+	"github.com/amalgam8/amalgam8/registry/api"
+)
+
+// Config encapsulates REST server configuration parameters
+type Config struct {
+	HTTPAddressSpec string
+	Discovery       api.ServiceDiscovery
+}

--- a/sidecar/register/discovery/discovery.go
+++ b/sidecar/register/discovery/discovery.go
@@ -1,0 +1,174 @@
+// Copyright 2016 IBM Corporation
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package discovery
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/ant0ine/go-json-rest/rest"
+
+	"github.com/amalgam8/amalgam8/registry/api"
+)
+
+const (
+	routeParamServiceName = "sname"
+	apiVer                = "/v1"
+	registrationPath      = apiVer + "/registration"
+	registrationTemplate  = registrationPath + "/#" + routeParamServiceName
+)
+
+// Hosts is the array of hosts returned by the GET registration
+type Hosts struct {
+	Hosts []Host `json:"hosts"`
+}
+
+// Host is the endpoint and tag data for a service instance
+type Host struct {
+	IPAddr string            `json:"ip_address"`
+	Port   uint16            `json:"port"`
+	Tags   map[string]string `json:"tags"`
+}
+
+// Discovery handles discovery API calls
+type Discovery struct {
+	discovery api.ServiceDiscovery
+}
+
+// NewDiscovery creates struct
+func NewDiscovery(discovery api.ServiceDiscovery) *Discovery {
+	return &Discovery{
+		discovery: discovery,
+	}
+}
+
+// Routes for discovery API
+func (d *Discovery) Routes(middlewares ...rest.Middleware) []*rest.Route {
+	routes := []*rest.Route{
+		rest.Get(registrationTemplate, d.getRegistration),
+	}
+
+	for _, route := range routes {
+		route.Func = rest.WrapMiddlewares(middlewares, route.Func)
+	}
+	return routes
+}
+
+// getRegistration
+func (d *Discovery) getRegistration(w rest.ResponseWriter, req *rest.Request) {
+	sname := req.PathParam(routeParamServiceName)
+	instances, err := d.discovery.ListServiceInstances(sname)
+	if err != nil {
+		logrus.WithError(err).Warnf("Failed to get the list of service instances")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
+	resp := Hosts{
+		Hosts: translate(instances),
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.WriteJson(&resp)
+	return
+}
+
+func translate(instances []*api.ServiceInstance) []Host {
+	hosts := []Host{}
+	tags := make(map[string]string)
+
+	for _, instance := range instances {
+		var host Host
+		ip, port, err := splitHostPort(instance.Endpoint)
+		if err != nil {
+			logrus.WithError(err).Warnf("unable to resolve ip address for instance '%s'", instance.ID)
+			continue
+		}
+		host = Host{IPAddr: ip, Port: port, Tags: tags}
+		hosts = append(hosts, host)
+	}
+
+	return hosts
+}
+
+func splitHostPort(endpoint api.ServiceEndpoint) (string, uint16, error) {
+	switch endpoint.Type {
+	case "tcp", "udp":
+		return splitHostPortTCPUDP(endpoint.Value)
+	case "http", "https":
+		return splitHostPortHTTP(endpoint.Value)
+	default:
+		return "", 0, fmt.Errorf("unsupported endpoint type: %s", endpoint.Type)
+	}
+}
+
+func splitHostPortTCPUDP(value string) (string, uint16, error) {
+	// Assume value is "host:port"
+	host, port, err := net.SplitHostPort(value)
+
+	// Assume value is "host" (no port)
+	if err != nil {
+		host = value
+		port = "0"
+	}
+
+	// A url will wind up being filtered out - should it be included?
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return "", 0, fmt.Errorf("could not parse '%s' as ip:port", value)
+	}
+
+	portNum, err := strconv.Atoi(port)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return ip.String(), uint16(portNum), nil
+}
+
+func splitHostPortHTTP(value string) (string, uint16, error) {
+	isHTTP := strings.HasPrefix(value, "http://")
+	isHTTPS := strings.HasPrefix(value, "https://")
+	if !isHTTPS && !isHTTP {
+		value = "http://" + value
+		isHTTP = true
+	}
+
+	parsedURL, err := url.Parse(value)
+	if err != nil {
+		return "", 0, err
+	}
+
+	ip, port, err := splitHostPortTCPUDP(parsedURL.Host)
+	if err != nil {
+		return "", 0, err
+	}
+
+	// Use default port, if not specified
+	if port == 0 {
+		if isHTTP {
+			port = 80
+		} else if isHTTPS {
+			port = 443
+		}
+	}
+
+	return ip, port, nil
+}

--- a/sidecar/register/server.go
+++ b/sidecar/register/server.go
@@ -64,7 +64,17 @@ func (s *server) Start() error {
 	if err != nil {
 		return err
 	}
-	return s.serve(handler)
+
+	go func() {
+		err = s.serve(handler)
+		if err != nil {
+			s.logger.WithFields(log.Fields{
+				"error": err,
+			}).Warn("Failed to start the server")
+		}
+	}()
+
+	return nil
 }
 
 func (s *server) Stop() {

--- a/sidecar/register/server.go
+++ b/sidecar/register/server.go
@@ -50,7 +50,7 @@ func NewDiscoveryServer(conf *Config) (Server, error) {
 	}
 
 	s := &server{
-		config: &*conf,
+		config: conf,
 		logger: logging.GetLogger(module),
 	}
 
@@ -80,10 +80,12 @@ func (s *server) Start() error {
 func (s *server) Stop() {
 	s.logger.Info("Stopping rest server")
 
-	if err := s.listener.Close(); err != nil {
-		s.logger.WithFields(log.Fields{
-			"error": err,
-		}).Warn("Failed to close listener")
+	if s.listener != nil {
+		if err := s.listener.Close(); err != nil {
+			s.logger.WithFields(log.Fields{
+				"error": err,
+			}).Warn("Failed to close listener")
+		}
 	}
 }
 
@@ -96,8 +98,6 @@ func (s *server) setup() (http.Handler, error) {
 		&rest.RecorderMiddleware{},
 		&rest.ContentTypeCheckerMiddleware{},
 	)
-
-	log.SetOutput(s.logger.Logger.Out)
 
 	discoveryAPI := discovery.NewDiscovery(s.config.Discovery)
 

--- a/sidecar/register/server.go
+++ b/sidecar/register/server.go
@@ -1,0 +1,126 @@
+// Copyright 2016 IBM Corporation
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package register
+
+import (
+	"errors"
+	"net"
+	"net/http"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/ant0ine/go-json-rest/rest"
+
+	"github.com/amalgam8/amalgam8/registry/utils/logging"
+	"github.com/amalgam8/amalgam8/sidecar/register/discovery"
+)
+
+const (
+	module = "SIDECARREGISTER"
+)
+
+// Server defines an interface for controlling server lifecycle
+type Server interface {
+	Start() error
+	Stop()
+}
+
+type server struct {
+	config   *Config
+	listener net.Listener
+	logger   *log.Entry
+}
+
+// NewDiscoveryServer creates a new server based on the provided configuration options.
+// Returns a valid Server interface on success or an error on failure
+func NewDiscoveryServer(conf *Config) (Server, error) {
+	if conf == nil {
+		return nil, errors.New("null Discovery configuration provided")
+	}
+
+	s := &server{
+		config: &*conf,
+		logger: logging.GetLogger(module),
+	}
+
+	s.logger.Infof("Creating Discovery REST API on %s", s.config.HTTPAddressSpec)
+
+	return s, nil
+}
+
+func (s *server) Start() error {
+	handler, err := s.setup()
+	if err != nil {
+		return err
+	}
+	return s.serve(handler)
+}
+
+func (s *server) Stop() {
+	s.logger.Info("Stopping rest server")
+
+	if err := s.listener.Close(); err != nil {
+		s.logger.WithFields(log.Fields{
+			"error": err,
+		}).Warn("Failed to close listener")
+	}
+}
+
+func (s *server) setup() (http.Handler, error) {
+	restAPI := rest.NewApi()
+
+	restAPI.Use(
+		&rest.RecoverMiddleware{},
+		&rest.TimerMiddleware{},
+		&rest.RecorderMiddleware{},
+		&rest.ContentTypeCheckerMiddleware{},
+	)
+
+	log.SetOutput(s.logger.Logger.Out)
+
+	discoveryAPI := discovery.NewDiscovery(s.config.Discovery)
+
+	var routes []*rest.Route
+	routes = append(routes, discoveryAPI.Routes()...)
+
+	router, err := rest.MakeRouter(routes...)
+	if err != nil {
+		return nil, err
+	}
+
+	restAPI.SetApp(router)
+	return restAPI.MakeHandler(), nil
+}
+
+func (s *server) serve(h http.Handler) error {
+	s.logger.Infof("Starting service discovery REST API on %s", s.config.HTTPAddressSpec)
+
+	listener, err := net.Listen("tcp", s.config.HTTPAddressSpec)
+	if err != nil {
+		s.logger.WithFields(log.Fields{
+			"error": err,
+		}).Error("Failed to start the server")
+		return err
+	}
+
+	s.listener = listener
+	if err := http.Serve(listener, h); err != nil {
+		s.logger.WithFields(log.Fields{
+			"error": err,
+		}).Warn("Server has aborted")
+		return err
+	}
+
+	return nil
+}

--- a/sidecar/register/server_test.go
+++ b/sidecar/register/server_test.go
@@ -108,6 +108,7 @@ func (suite *TestSuite) SetupTest() {
 
 func (suite *TestSuite) TearDownTest() {
 	discoveryServer.Stop()
+	time.Sleep((200) * time.Millisecond)
 }
 
 func (suite *TestSuite) TestGetRegistrationCart() {

--- a/sidecar/register/server_test.go
+++ b/sidecar/register/server_test.go
@@ -1,0 +1,239 @@
+package register
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/amalgam8/amalgam8/registry/api"
+	"github.com/amalgam8/amalgam8/sidecar/register/discovery"
+	"github.com/stretchr/testify/suite"
+)
+
+type TestSuite struct {
+	suite.Suite
+	server   *Server
+	config   Config
+	myClient *mySimpleServiceDiscovery
+}
+
+/********************* Mock client ***************************/
+var discoveryServer Server
+var returnError bool
+
+type mySimpleServiceDiscovery struct {
+	services []*api.ServiceInstance
+}
+
+// ListServices queries the registry for the list of services for which instances are currently registered.
+func (m *mySimpleServiceDiscovery) ListServices() ([]string, error) {
+	servicesNames := []string{}
+	for _, service := range m.services {
+		servicesNames = append(servicesNames, service.ServiceName)
+	}
+	return servicesNames, nil
+}
+
+// ListInstances queries the registry for the list of service instances currently registered.
+func (m *mySimpleServiceDiscovery) ListInstances() ([]*api.ServiceInstance, error) {
+	servicesToReturn := []*api.ServiceInstance{}
+	servicesToReturn = append(servicesToReturn, m.services...)
+	return servicesToReturn, nil
+}
+
+// ListServiceInstances queries the registry for the list of service instances with status 'UP' currently
+// registered for the given service.
+func (m *mySimpleServiceDiscovery) ListServiceInstances(serviceName string) ([]*api.ServiceInstance, error) {
+
+	servicesToReturn := []*api.ServiceInstance{}
+	if returnError {
+		return servicesToReturn, fmt.Errorf("Some error has occurred")
+	}
+
+	for _, service := range m.services {
+		if service.ServiceName == serviceName {
+			servicesToReturn = append(servicesToReturn, service)
+
+		}
+
+	}
+	return servicesToReturn, nil
+}
+
+// create the discovery server with a client , initialize registry with service instances.
+func (suite *TestSuite) SetupTest() {
+	var err error
+	suite.myClient = new(mySimpleServiceDiscovery)
+
+	suite.config = Config{
+		HTTPAddressSpec: ":6500",
+		Discovery:       suite.myClient,
+	}
+
+	discoveryServer, err = NewDiscoveryServer(&suite.config)
+	suite.NoError(err)
+	suite.server = &discoveryServer
+
+	suite.myClient.services = append(suite.myClient.services, &api.ServiceInstance{ServiceName: "shoppingCart",
+		ID: "1", Endpoint: api.ServiceEndpoint{Type: "http", Value: "http://amalgam8/shopping/cart"}})
+
+	suite.myClient.services = append(suite.myClient.services, &api.ServiceInstance{ServiceName: "shoppingCart",
+		ID: "2", Endpoint: api.ServiceEndpoint{Type: "tcp", Value: "127.0.0.5:5050"}})
+
+	suite.myClient.services = append(suite.myClient.services, &api.ServiceInstance{Tags: []string{"first", "second"},
+		ServiceName: "shoppingCart", ID: "3", Endpoint: api.ServiceEndpoint{Type: "tcp", Value: "127.0.0.4:3050"}})
+
+	suite.myClient.services = append(suite.myClient.services, &api.ServiceInstance{ServiceName: "Orders",
+		ID: "4", Endpoint: api.ServiceEndpoint{Type: "tcp", Value: "127.0.0.10:3050"}})
+
+	suite.myClient.services = append(suite.myClient.services, &api.ServiceInstance{ServiceName: "Orders",
+		ID: "6", Endpoint: api.ServiceEndpoint{Type: "http", Value: "http://127.0.0.11"}})
+
+	suite.myClient.services = append(suite.myClient.services, &api.ServiceInstance{ServiceName: "Orders",
+		ID: "7", Endpoint: api.ServiceEndpoint{Type: "tcp", Value: "132.68.5.6:1010"}})
+
+	suite.myClient.services = append(suite.myClient.services, &api.ServiceInstance{ServiceName: "Reviews",
+		ID: "8", Endpoint: api.ServiceEndpoint{Type: "tcp", Value: "132.68.5.6:1010"}})
+
+	suite.myClient.services = append(suite.myClient.services, &api.ServiceInstance{ServiceName: "httpsService",
+		ID: "9", Endpoint: api.ServiceEndpoint{Type: "https", Value: "https://127.0.0.12"}})
+
+	go discoveryServer.Start()
+	time.Sleep((200) * time.Millisecond)
+
+}
+
+func (suite *TestSuite) TearDownTest() {
+	discoveryServer.Stop()
+}
+
+func (suite *TestSuite) TestGetRegistrationCart() {
+	baseURL := "http://localhost:6500/v1/registration"
+	handler, _ := discoveryServer.(*server).setup()
+	recorder := httptest.NewRecorder()
+
+	// Get shoppingCart service
+	req, err := http.NewRequest("GET", baseURL+"/shoppingCart", nil)
+	suite.NoError(err)
+	handler.ServeHTTP(recorder, req)
+	suite.Equal(recorder.Code, http.StatusOK)
+
+	var registration discovery.Hosts
+
+	err = json.Unmarshal(recorder.Body.Bytes(), &registration)
+	suite.NoError(err)
+	// The url endpoint will be filtered out
+	suite.Len(registration.Hosts, 2, "Should be two records for shoppingCart")
+}
+
+func (suite *TestSuite) TestGetRegistrationOrders() {
+	baseURL := "http://localhost:6500/v1/registration"
+	handler, _ := discoveryServer.(*server).setup()
+	recorder := httptest.NewRecorder()
+
+	// Get Orders service instances
+	req, err := http.NewRequest("GET", baseURL+"/Orders", nil)
+	suite.NoError(err)
+	handler.ServeHTTP(recorder, req)
+	suite.Equal(recorder.Code, http.StatusOK)
+
+	var registration discovery.Hosts
+
+	err = json.Unmarshal(recorder.Body.Bytes(), &registration)
+	suite.NoError(err)
+	suite.Len(registration.Hosts, 3, "Should be three records for Orders")
+}
+
+func (suite *TestSuite) TestGetRegistrationReviews() {
+	baseURL := "http://localhost:6500/v1/registration"
+	handler, _ := discoveryServer.(*server).setup()
+	recorder := httptest.NewRecorder()
+
+	// Get Orders service instances
+	req, err := http.NewRequest("GET", baseURL+"/Reviews", nil)
+	suite.NoError(err)
+	handler.ServeHTTP(recorder, req)
+	suite.Equal(recorder.Code, http.StatusOK)
+
+	var registration discovery.Hosts
+
+	err = json.Unmarshal(recorder.Body.Bytes(), &registration)
+	suite.NoError(err)
+	suite.Len(registration.Hosts, 1, "Should be one record for Reviews")
+}
+
+func (suite *TestSuite) TestGetRegistrationHttpsService() {
+	baseURL := "http://localhost:6500/v1/registration"
+	handler, _ := discoveryServer.(*server).setup()
+	recorder := httptest.NewRecorder()
+
+	// Get Orders service instances
+	req, err := http.NewRequest("GET", baseURL+"/httpsService", nil)
+	suite.NoError(err)
+	handler.ServeHTTP(recorder, req)
+	suite.Equal(recorder.Code, http.StatusOK)
+
+	var registration discovery.Hosts
+
+	err = json.Unmarshal(recorder.Body.Bytes(), &registration)
+	suite.NoError(err)
+	suite.Len(registration.Hosts, 1, "Should be one record for httpsService")
+	// Default https port
+	suite.Equal(registration.Hosts[0].Port, uint16(443))
+}
+
+func (suite *TestSuite) TestGetRegistrationServiceNotFound() {
+	baseURL := "http://localhost:6500/v1/registration"
+	handler, _ := discoveryServer.(*server).setup()
+	recorder := httptest.NewRecorder()
+
+	// Get Orders service instances
+	req, err := http.NewRequest("GET", baseURL+"/noservice", nil)
+	suite.NoError(err)
+	handler.ServeHTTP(recorder, req)
+	suite.Equal(recorder.Code, http.StatusOK)
+
+	var registration discovery.Hosts
+
+	err = json.Unmarshal(recorder.Body.Bytes(), &registration)
+	suite.NoError(err)
+	suite.Len(registration.Hosts, 0, "Should be no records")
+}
+
+func (suite *TestSuite) TestGetRegistrationServiceNotSpecified() {
+	baseURL := "http://localhost:6500/v1/registration"
+	handler, _ := discoveryServer.(*server).setup()
+	recorder := httptest.NewRecorder()
+
+	// Get Orders service instances
+	req, err := http.NewRequest("GET", baseURL+"/", nil)
+	suite.NoError(err)
+	handler.ServeHTTP(recorder, req)
+	suite.Equal(recorder.Code, http.StatusNotFound)
+}
+
+func (suite *TestSuite) TestGetRegistrationError() {
+	returnError = true
+
+	baseURL := "http://localhost:6500/v1/registration"
+	handler, _ := discoveryServer.(*server).setup()
+	recorder := httptest.NewRecorder()
+
+	// Get Orders service instances
+	req, err := http.NewRequest("GET", baseURL+"/Reviews", nil)
+	suite.NoError(err)
+	handler.ServeHTTP(recorder, req)
+	suite.Equal(recorder.Code, http.StatusServiceUnavailable)
+
+	returnError = false
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestTestSuite(t *testing.T) {
+
+	suite.Run(t, new(TestSuite))
+}

--- a/sidecar/sidecar.go
+++ b/sidecar/sidecar.go
@@ -101,6 +101,25 @@ func Run(conf config.Config) error {
 			logrus.WithError(err).Error("Could not create service discovery backend adapter")
 			return err
 		}
+
+		if conf.DiscoveryPort == 0 {
+			conf.DiscoveryPort = 6500
+		}
+
+		serverConfig := &register.Config{
+			HTTPAddressSpec: fmt.Sprintf(":%d", conf.DiscoveryPort),
+			Discovery:       discovery,
+		}
+		server, err := register.NewDiscoveryServer(serverConfig)
+		if err != nil {
+			logrus.WithError(err).Error("Discovery server failed to start")
+			return err
+		}
+		err = server.Start()
+		if err != nil {
+			logrus.WithError(err).Error("Discovery server failed to start")
+			return err
+		}
 	}
 
 	if conf.DNS {
@@ -169,25 +188,6 @@ func Run(conf config.Config) error {
 		// Delay slightly to give time for the application to start
 		// TODO: make this delay configurable or implement a better solution.
 		time.AfterFunc(1*time.Second, lifecycle.Start)
-	}
-
-	if conf.DiscoveryPort == 0 {
-		conf.DiscoveryPort = 6500
-	}
-
-	serverConfig := &register.Config{
-		HTTPAddressSpec: fmt.Sprintf(":%d", conf.DiscoveryPort),
-		Discovery:       discovery,
-	}
-	server, err := register.NewDiscoveryServer(serverConfig)
-	if err != nil {
-		logrus.WithError(err).Error("Discovery server failed to start")
-		return err
-	}
-	err = server.Start()
-	if err != nil {
-		logrus.WithError(err).Error("Discovery server failed to start")
-		return err
 	}
 
 	appSupervisor := supervisor.NewAppSupervisor(&conf, lifecycle)

--- a/sidecar/sidecar.go
+++ b/sidecar/sidecar.go
@@ -102,10 +102,6 @@ func Run(conf config.Config) error {
 			return err
 		}
 
-		if conf.DiscoveryPort == 0 {
-			conf.DiscoveryPort = 6500
-		}
-
 		serverConfig := &register.Config{
 			HTTPAddressSpec: fmt.Sprintf(":%d", conf.DiscoveryPort),
 			Discovery:       discovery,

--- a/sidecar/sidecar.go
+++ b/sidecar/sidecar.go
@@ -171,6 +171,25 @@ func Run(conf config.Config) error {
 		time.AfterFunc(1*time.Second, lifecycle.Start)
 	}
 
+	if conf.DiscoveryPort == 0 {
+		conf.DiscoveryPort = 6500
+	}
+
+	serverConfig := &register.Config{
+		HTTPAddressSpec: fmt.Sprintf(":%d", conf.DiscoveryPort),
+		Discovery:       discovery,
+	}
+	server, err := register.NewDiscoveryServer(serverConfig)
+	if err != nil {
+		logrus.WithError(err).Error("Discovery server failed to start")
+		return err
+	}
+	err = server.Start()
+	if err != nil {
+		logrus.WithError(err).Error("Discovery server failed to start")
+		return err
+	}
+
 	appSupervisor := supervisor.NewAppSupervisor(&conf, lifecycle)
 	appSupervisor.DoAppSupervision()
 


### PR DESCRIPTION
Instead of the sidecar pushing new updates to the proxy (whether its
nginx or envoy), the sidecar could also listen on a localhost endpoint
where the proxy could poll periodically to obtain upstream instances
(the registry data). This model would decouple the proxy implementation
from the sidecar agent and allow us to switch between different proxies
as well.

At minimum, the sidecar needs to support Envoy's API endpoint for
service discovery.