### PR TITLE
Shrink released binaries using stripping and UPX compression

### DIFF
--- a/testing/apps/details/Makefile
+++ b/testing/apps/details/Makefile
@@ -2,7 +2,7 @@ APP_NAME := $(shell basename `pwd`)
 IMAGE_NAME := amalgam8/a8-testing-bookinfo-$(APP_NAME)
 
 build:
-	@go build -o $(APP_NAME) -a -installsuffix nocgo -tags netgo
+	@go build -o $(APP_NAME) -a -installsuffix nocgo -tags netgo -ldflags "-s -w"
 	
 dockerize:
 	@docker build -t $(IMAGE_NAME):v1 .

--- a/testing/apps/productpage/Makefile
+++ b/testing/apps/productpage/Makefile
@@ -2,7 +2,7 @@ APP_NAME := $(shell basename `pwd`)
 IMAGE_NAME := amalgam8/a8-testing-bookinfo-$(APP_NAME)
 
 build:
-	@go build -o $(APP_NAME) -a -installsuffix nocgo -tags netgo
+	@go build -o $(APP_NAME) -a -installsuffix nocgo -tags netgo -ldflags "-s -w"
 	
 dockerize:
 	@docker build -t $(IMAGE_NAME):v1 .

--- a/testing/apps/ratings/Makefile
+++ b/testing/apps/ratings/Makefile
@@ -2,7 +2,7 @@ APP_NAME := $(shell basename `pwd`)
 IMAGE_NAME := amalgam8/a8-testing-bookinfo-$(APP_NAME)
 
 build:
-	@go build -o $(APP_NAME) -a -installsuffix nocgo -tags netgo
+	@go build -o $(APP_NAME) -a -installsuffix nocgo -tags netgo -ldflags "-s -w"
 	
 dockerize:
 	@docker build -t $(IMAGE_NAME):v1 .

--- a/testing/apps/reviews/Makefile
+++ b/testing/apps/reviews/Makefile
@@ -2,7 +2,7 @@ APP_NAME := $(shell basename `pwd`)
 IMAGE_NAME := amalgam8/a8-testing-bookinfo-$(APP_NAME)
 
 build:
-	@go build -o $(APP_NAME) -a -installsuffix nocgo -tags netgo
+	@go build -o $(APP_NAME) -a -installsuffix nocgo -tags netgo -ldflags "-s -w"
 	
 dockerize: dockerize-v1 dockerize-v2 dockerize-v3
 


### PR DESCRIPTION
The following PR applies two methods to significantly shrink the size of our released binaries, based on the [following method](https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/).
1. Strip symbol tables and debug information using the `-s -w` [linker flags](https://golang.org/cmd/link/).
  This shrinks the binary by about %25-%50, while still keeping types/methods/filepaths to be displayed in panic stack traces.
2. Compress the binary into a self-decompressing executable using [UPX](https://upx.github.io/):
  This further shrinks the binary by an additional %80, to a total of about %90!
  The cost is the decompression latency when invoking the executable, which ranges between 100-400ms, depending on binary size and compression method.
  
Note that binary size was not much of a concern until now, being around 10-11 MB per binary.
But, with the reimplementation of the kubernetes adapter using the [official kubernetes go client](https://github.com/kubernetes/client-go) (in a separate PR), the `a8registry` & `a8sidecar` binaries sizes have skyrocketed to ~50 MB.
Combining the two methods above, the binary sizes are significantly reduced:

```bash
zvic@zvic-vbox:~/Workspace/go/src/github.com/amalgam8/amalgam8/bin (compress_binaries)$ ll -h
total 88M
drwxrwxr-x  2 zvic zvic 4.0K Nov 23 15:56 ./
drwxrwxr-x 20 zvic zvic 4.0K Nov 23 15:49 ../
-rwxrwxr-x  1 zvic zvic  46M Nov 23 11:27 a8sidecar*
-rwxrwxr-x  1 zvic zvic  26M Nov 23 11:24 a8sidecar-stripped*
-rwxrwxr-x  1 zvic zvic 6.0M Nov 23 11:24 a8sidecar-stripped-upx*
-rwxrwxr-x  1 zvic zvic 5.7M Nov 23 11:24 a8sidecar-stripped-upx-best*
-rwxrwxr-x  1 zvic zvic 4.5M Nov 23 11:24 a8sidecar-stripped-upx-best-ultra*
```

- `a8sidecar` (our vanilla sidecar) as well as `a8sidecar-stripped` starts up in about 50 ms.
- `a8sidecar-stripped-upx` (default compression method) as well as `a8sidecar-stripped-upx-best` (best compression method) starts up in about 150 ms.
- `a8sidecar-stripped-upx-best-ultra` (better than best compression :smile:) starts up in about 450 ms.

Two additional notes:
- According to the UPX docs, the produced executables are self-containing (no dependencies, statically linked) are should be able to run on any linux platform capable of running ELF executables (i.e., any).
- We need to make sure there are no issues with [UPX license](https://github.com/upx/upx/blob/master/LICENSE). For my understanding, the only section which applies to us is [SPECIAL EXCEPTION FOR COMPRESSED EXECUTABLES](https://github.com/upx/upx/blob/master/LICENSE#L68), which doesn't apply any special restrictions or requirements on us. @ericvn I'd appreciate if you could take a look and see if we can clear that.