### PR TITLE
Add a debug API to the reviews service

### DIFF
--- a/testing/apps/reviews/reviews.go
+++ b/testing/apps/reviews/reviews.go
@@ -75,6 +75,16 @@ func main() {
 
 	http.HandleFunc("/reviews", reviewsHandler)
 	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		conf := struct {
+			EnableRatings bool
+			StarColor     string
+		}{
+			EnableRatings: enableRatings,
+			StarColor:     starColor,
+		}
+
+		data, _ := json.Marshal(&conf)
+		w.Write(data)
 		w.WriteHeader(http.StatusOK)
 	})
 	log.Fatal(http.ListenAndServe(":"+port, nil))


### PR DESCRIPTION
Added a handy API to the reviews service for debugging proxying issues. The API is only ever called manually.