### PR TITLE
Removes nested matches from the rule schema.

### DIFF
--- a/pkg/api/rules-schema.json
+++ b/pkg/api/rules-schema.json
@@ -22,27 +22,6 @@
     "match": {
       "type": "object",
       "properties": {
-        "all": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/match"
-          }
-        },
-        "any": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/match"
-          }
-        },
-        "none": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/match"
-          }
-        },
         "source": {
           "$ref": "#/definitions/source"
         },


### PR DESCRIPTION
Nested matching is not supported. This PR updates the schema to reflect this.