### PR TITLE
Enable helloworld testcase for examples automation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,7 @@ examples/docker-helloworld.yaml
 examples/k8s-bookinfo.yaml
 examples/k8s-controlplane.yaml
 examples/k8s-helloworld.yaml
-
+examples/docker-helloworld-default-route-rules.json
+examples/docker-helloworld-v1-v2-route-rules.json
+examples/k8s-helloworld-default-route-rules.yaml
+examples/k8s-helloworld-v1-v2-route-rules.yaml

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ test.integration: build.testapps
 	@echo "--> running integration tests"
 	@testing/run_tests.sh
 
-test.examples: build.exampleapps dockerize.sidecar.envoy.ubuntu
+test.examples: build.exampleapps dockerize.sidecar.envoy.ubuntu dockerize.k8srules
 	@echo "--> running automated examples"
 	@testing/run_tests.sh "examples" $(APP_VER_ABBR)
 

--- a/testing/generate_example_yaml.sh
+++ b/testing/generate_example_yaml.sh
@@ -39,6 +39,7 @@ replace(){
 
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 EXAMPLESDIR=$SCRIPTDIR/../examples
+TEST_SCRIPTS_DIR=$SCRIPTDIR/test-scripts
 
 ##### DOCKER ######
 DOCKER_DIR=$SCRIPTDIR/docker
@@ -46,6 +47,9 @@ DOCKER_DIR=$SCRIPTDIR/docker
 replace $DOCKER_DIR/bookinfo.yaml $EXAMPLESDIR/docker-bookinfo.yaml
 replace $DOCKER_DIR/helloworld.yaml $EXAMPLESDIR/docker-helloworld.yaml
 cp $DOCKER_DIR/controlplane.yaml $EXAMPLESDIR/docker-controlplane.yaml
+# Copy the rules over to examples/
+cp $TEST_SCRIPTS_DIR/helloworld-default-route-rules.json $EXAMPLESDIR/docker-helloworld-default-route-rules.json
+cp $TEST_SCRIPTS_DIR/helloworld-v1-v2-route-rules.json $EXAMPLESDIR/docker-helloworld-v1-v2-route-rules.json
 
 ##### K8S ######
 K8S_DIR=$SCRIPTDIR/kubernetes
@@ -53,6 +57,9 @@ K8S_DIR=$SCRIPTDIR/kubernetes
 replace $K8S_DIR/bookinfo.yaml $EXAMPLESDIR/k8s-bookinfo.yaml
 replace $K8S_DIR/helloworld.yaml $EXAMPLESDIR/k8s-helloworld.yaml
 cp $K8S_DIR/controlplane.yaml $EXAMPLESDIR/k8s-controlplane.yaml
+# Copy the rules over to examples/
+cp $TEST_SCRIPTS_DIR/helloworld-default-route-rules.yaml $EXAMPLESDIR/k8s-helloworld-default-route-rules.yaml
+cp $TEST_SCRIPTS_DIR/helloworld-v1-v2-route-rules.yaml $EXAMPLESDIR/k8s-helloworld-v1-v2-route-rules.yaml
 
 ##### Bluemix cfg file #####
 replace $SCRIPTDIR/bluemix.cfg $EXAMPLESDIR/bluemix.cfg

--- a/testing/kubernetes/helloworld.yaml
+++ b/testing/kubernetes/helloworld.yaml
@@ -83,7 +83,7 @@ spec:
     spec:
       containers:
       - name: helloworld
-        image: amalgam8/a8-examples-helloworld-v1:latest
+        image: amalgam8/a8-examples-helloworld-v1:${A8_RELEASE}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 5000
@@ -105,7 +105,7 @@ spec:
     spec:
       containers:
       - name: helloworld
-        image: amalgam8/a8-examples-helloworld-v2:latest
+        image: amalgam8/a8-examples-helloworld-v2:${A8_RELEASE}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 5000

--- a/testing/kubernetes/install-kubernetes.sh
+++ b/testing/kubernetes/install-kubernetes.sh
@@ -16,28 +16,26 @@
 
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-export K8S_VERSION="v1.2.3"
+export K8S_VERSION="v1.5.2"
 export ARCH=amd64
 
-docker run \
-    --volume=/:/rootfs:ro \
-    --volume=/sys:/sys:ro \
+docker run -d \
+    --volume=/sys:/sys:rw \
     --volume=/var/lib/docker/:/var/lib/docker:rw \
-    --volume=/var/lib/kubelet/:/var/lib/kubelet:rw \
+    --volume=/var/lib/kubelet/:/var/lib/kubelet:rw,shared \
     --volume=/var/run:/var/run:rw \
     --net=host \
     --pid=host \
-    --privileged=true \
+    --privileged \
     --name=kubelet \
-    -d \
     gcr.io/google_containers/hyperkube-${ARCH}:${K8S_VERSION} \
     /hyperkube kubelet \
-        --containerized \
         --hostname-override=127.0.0.1 \
-        --address=0.0.0.0 \
-        --api-servers=http://0.0.0.0:8080 \
+        --api-servers=http://localhost:8080 \
         --config=/etc/kubernetes/manifests \
-        --allow-privileged=true --v=2
+        --cluster-dns=10.0.0.10 \
+        --cluster-domain=cluster.local \
+        --allow-privileged --v=2
 
 # Install kubernetes CLI
 curl -L http://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/${ARCH}/kubectl > /tmp/kubectl

--- a/testing/kubernetes/test-kubernetes.sh
+++ b/testing/kubernetes/test-kubernetes.sh
@@ -67,6 +67,8 @@ if [ "$A8_TEST_SUITE" == "examples" ]; then
     BOOKINFO_YAML=$SCRIPTDIR/../../examples/k8s-bookinfo.yaml
     CONTROLPLANE_YAML=$SCRIPTDIR/../../examples/k8s-controlplane.yaml
 else
+    # Disable the k8s integration tests for now
+    exit 0
     echo "======= Running the integration test suite ======="
     export A8_TEST_ENV="testing"
     HELLOWORLD_YAML=$SCRIPTDIR/helloworld.yaml
@@ -92,17 +94,18 @@ echo "Starting control plane"
 startup_pods $CONTROLPLANE_YAML
 sleep 10
 
-startup_pods $BOOKINFO_YAML
-echo "Waiting for the services to come online.."
-sleep 10
+# Disable the bookinfo tests for k8s for now
+#startup_pods $BOOKINFO_YAML
+#echo "Waiting for the services to come online.."
+#sleep 10
 
 # Run the actual test workload
-$SCRIPTDIR/../test-scripts/bookinfo.sh $A8_TEST_SUITE
+#$SCRIPTDIR/../test-scripts/bookinfo.sh $A8_TEST_SUITE
 
-echo "Kubernetes tests successful."
-echo "Cleaning up Bookinfo apps.."
-shutdown_pods $BOOKINFO_YAML || echo "Probably already down"
-sleep 5
+#echo "Kubernetes tests successful."
+#echo "Cleaning up Bookinfo apps.."
+#shutdown_pods $BOOKINFO_YAML || echo "Probably already down"
+#sleep 5
 
 if [ "$A8_TEST_SUITE" == "examples" ]; then
 	startup_pods $HELLOWORLD_YAML

--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -29,9 +29,9 @@ if [ -z "$A8_TEST_DOCKER" ]; then
     A8_TEST_DOCKER="true"
 fi
 
-#if [ -z "$A8_TEST_K8S" ]; then
-#    A8_TEST_K8S="true"
-#fi
+if [ -z "$A8_TEST_K8S" ]; then
+    A8_TEST_K8S="true"
+fi
 
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 

--- a/testing/test-scripts/helloworld-v1-v2-route-rules.json
+++ b/testing/test-scripts/helloworld-v1-v2-route-rules.json
@@ -1,2 +1,2 @@
-{"rules": [{"priority": 1, "route": {"backends": [{"weight": 0.25, "tags": ["version=v2"]}, {"tags": ["version=v1"]}]}, "destination": "helloworld"}]}
+{"rules": [{"priority": 2, "route": {"backends": [{"weight": 0.25, "tags": ["version=v2"]}]}, "destination": "helloworld"}]}
 

--- a/testing/test-scripts/helloworld-v1-v2-route-rules.yaml
+++ b/testing/test-scripts/helloworld-v1-v2-route-rules.yaml
@@ -24,5 +24,3 @@ spec:
       - weight: 0.25
         tags:
         - "version=v2"
-      - tags:
-        - "version=v1"

--- a/testing/test-scripts/helloworld-v1-v2-route-rules.yaml
+++ b/testing/test-scripts/helloworld-v1-v2-route-rules.yaml
@@ -24,3 +24,5 @@ spec:
       - weight: 0.25
         tags:
         - "version=v2"
+      - tags:
+        - "version=v1"

--- a/testing/test-scripts/helloworld.sh
+++ b/testing/test-scripts/helloworld.sh
@@ -14,16 +14,17 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-set -o errexit
-
 # docker or k8s
-ENV=$1
+if [ -z "$A8_CONTAINER_ENV" ]; then
+    A8_CONTAINER_ENV="docker"
+fi
+ENV=$A8_CONTAINER_ENV
 
 # Dump some possibly useful data on failures to help debug
 dump_debug() {
-    curl localhost:31200/v1/rules
 
     if [ "$ENV" == "docker" ]; then
+        curl localhost:31200/v1/rules
         docker exec -it gateway a8sidecar --debug show-state
         docker logs gateway
         docker exec gateway ps aux
@@ -37,6 +38,7 @@ dump_debug() {
     fi
 
     if [ "$ENV" == "k8s" ]; then
+        kubectl get routingrule -o json
 	PODNAME=$(kubectl get pods | grep gateway | awk '{print $1}')
 	kubectl exec $PODNAME -- a8sidecar --debug show-state
 	kubectl logs $PODNAME
@@ -51,26 +53,32 @@ MAX_LOOP=5
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 A8CLI=$SCRIPTDIR/../../bin/a8ctl-beta-linux
 
+. $SCRIPTDIR/testing-common.sh
+
 # On single runs, have seen the routing to not be 100% following the
 # rule set.  So will loop to retry a few times to see if can get a
 # passing test.
-# TODO: add k8s TPR based testing
 retry_count=1
 while [  $retry_count -le $((MAX_LOOP)) ]; do
     ############# Set/Verify setting of default route #############
 
     # Clean up the routing rules from the previous testcase
-    $A8CLI rule-delete -a -f
+    cleanup_all_rules
 
     echo ""
     echo "Set/verify the Hello World default route to v1"
-    echo "  Invoking a8ctl to set the default route"
-    $A8CLI rule-create -f $SCRIPTDIR/helloworld-default-route-rules.json > /tmp/a8ctl_output.txt
+    if [ "$ENV" == "docker" ]; then
+        create_rule $SCRIPTDIR/helloworld-default-route-rules.json
+    else
+        create_rule $SCRIPTDIR/helloworld-default-route-rules.yaml
+    fi
+
+    sleep 15
 
     echo ""
-    echo "  Calling the Controller /v1/rules API to verify the route was set to helloworld v1"
-    temp_var1=$(curl -s -X "GET" $A8_CONTROLLER_URL/v1/rules | jq -r '.rules[0].destination')
-    temp_var2=$(curl -s -X "GET" $A8_CONTROLLER_URL/v1/rules | jq -r '.rules[0].route.backends[0].tags[0]')
+    echo "  Verifying the route was set to helloworld v1"
+    temp_var1=$(list_rules "destination")
+    temp_var2=$(list_rules "route.backends[0].tags[0]")
 
     if [ "${temp_var1}" != "helloworld" ] || [ "${temp_var2}" != "version=v1" ]; then
         echo "  The default route was not set as expected."
@@ -81,9 +89,6 @@ while [  $retry_count -le $((MAX_LOOP)) ]; do
         echo "  Passed test"
         echo ""
     fi
-
-    # Sleep a bit to make sure the rules are applied
-    sleep 5
 
     ############# Test traffic routes to v1 #############
     echo ""
@@ -125,27 +130,31 @@ done
 # On single runs, have seen the routing to not be 100% following the
 # rule set.  So will loop to retry a few times to see if can get an
 # approximate test of 75%/25% routing.
-# TODO: add k8s TPR based testing
 retry_count=1
 while [  $retry_count -le $((MAX_LOOP)) ]; do
     ############# Split Traffic Between v1 and v2 #############
 
     # Clean up the routing rules from the previous testcase
-    $A8CLI rule-delete -a -f
+    cleanup_all_rules
 
     echo ""
     echo "Set/verify the Hello World route to 75%/v1 25%/v2"
-    echo "  Invoking a8ctl to set a rule to split the traffic."
-    $A8CLI rule-create -f $SCRIPTDIR/helloworld-v1-v2-route-rules.json > /tmp/a8ctl_output.txt
+    if [ "$ENV" == "docker" ]; then
+        create_rule $SCRIPTDIR/helloworld-v1-v2-route-rules.json
+    else
+        create_rule $SCRIPTDIR/helloworld-v1-v2-route-rules.yaml
+    fi
+
+    sleep 15
 
     echo ""
-    echo "  Calling the Controller API to verify the rule was set."
+    echo "  Verifying the rule was set."
     for count in {0..1}
     do
-        temp_var1=$(curl -s -X "GET" $A8_CONTROLLER_URL/v1/rules | jq -r '.rules[0].route.backends['"$count"'].tags[0]')
+	temp_var1=$(list_rules "route.backends[$count].tags[0]")
 
-        if [ "${temp_var1}" == "v1" ]; then
-            temp_var2=$(curl -s -X "GET" $A8_CONTROLLER_URL/v1/rules | jq -r '.rules[0].route.backends['"$count"'].weight')
+        if [ "${temp_var1}" == "version=v1" ]; then
+	    temp_var2=$(list_rules "route.backends[$count].weight")
 
             if [ "${temp_var2}" != "null" ]; then
                 echo "    The v1 route was not set as the default 75% as expected."
@@ -158,7 +167,7 @@ while [  $retry_count -le $((MAX_LOOP)) ]; do
         fi
 
         if [ "${temp_var1}" == "version=v2" ]; then
-            temp_var2=$(curl -s -X "GET" $A8_CONTROLLER_URL/v1/rules | jq -r '.rules[0].route.backends['"$count"'].weight')
+            temp_var2=$(list_rules "route.backends[$count].weight")
 
             if [ "${temp_var2}" != "0.25" ]; then
                 echo "    The v2 route was not set to 25% as expected."
@@ -172,8 +181,6 @@ while [  $retry_count -le $((MAX_LOOP)) ]; do
     done
     echo "  Passed test"
     echo ""
-
-    sleep 5
 
     ############# Test traffic is split between v1 and v2 #############
     echo ""
@@ -218,7 +225,7 @@ while [  $retry_count -le $((MAX_LOOP)) ]; do
 done
 
 # Clean up the routing rules from the previous testcase
-$A8CLI rule-delete -a -f
+cleanup_all_rules
 
 echo ""
 echo "Verification of the Hello World example application completed successfully."

--- a/testing/test-scripts/helloworld.sh
+++ b/testing/test-scripts/helloworld.sh
@@ -51,6 +51,7 @@ dump_debug() {
 MAX_LOOP=5
 
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+EXAMPLESDIR=$SCRIPTDIR/../../examples
 A8CLI=$SCRIPTDIR/../../bin/a8ctl-beta-linux
 
 . $SCRIPTDIR/testing-common.sh
@@ -68,9 +69,9 @@ while [  $retry_count -le $((MAX_LOOP)) ]; do
     echo ""
     echo "Set/verify the Hello World default route to v1"
     if [ "$ENV" == "docker" ]; then
-        create_rule $SCRIPTDIR/helloworld-default-route-rules.json
+        create_rule $EXAMPLESDIR/docker-helloworld-default-route-rules.json
     else
-        create_rule $SCRIPTDIR/helloworld-default-route-rules.yaml
+        create_rule $EXAMPLESDIR/k8s-helloworld-default-route-rules.yaml
     fi
 
     sleep 15
@@ -134,15 +135,12 @@ retry_count=1
 while [  $retry_count -le $((MAX_LOOP)) ]; do
     ############# Split Traffic Between v1 and v2 #############
 
-    # Clean up the routing rules from the previous testcase
-    cleanup_all_rules
-
     echo ""
     echo "Set/verify the Hello World route to 75%/v1 25%/v2"
     if [ "$ENV" == "docker" ]; then
-        create_rule $SCRIPTDIR/helloworld-v1-v2-route-rules.json
+        create_rule $EXAMPLESDIR/docker-helloworld-v1-v2-route-rules.json
     else
-        create_rule $SCRIPTDIR/helloworld-v1-v2-route-rules.yaml
+        create_rule $EXAMPLESDIR/k8s-helloworld-v1-v2-route-rules.yaml
     fi
 
     sleep 15

--- a/testing/test-scripts/testing-common.sh
+++ b/testing/test-scripts/testing-common.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+cleanup_all_rules() {
+    if [ "$ENV" == "docker" ]; then
+        echo "Cleaning up docker rules"
+        $A8CLI rule-delete -a -f
+	return $?
+    fi
+
+    if [ "$ENV" == "k8s" ]; then
+        echo "Cleaning up k8s rules"
+        kubectl delete routingrule --all 
+	return $?
+    fi
+
+    echo "ENV is not set.  Exiting...."
+    exit 1
+}
+
+create_rule() {
+    if [ "$ENV" == "docker" ]; then
+	echo $($A8CLI rule-create -f $1)
+        return $?
+    fi
+
+    if [ "$ENV" == "k8s" ]; then
+	echo $(kubectl create -f $1)
+        return $?
+    fi
+
+    echo "ENV is not set.  Exiting...."
+    exit 1
+}
+
+list_rules() {
+    FIELD=$1
+    if [ "$ENV" == "docker" ]; then
+        echo $(curl -s -X "GET" $A8_CONTROLLER_URL/v1/rules | jq -r .rules[0].$FIELD)
+	return 0
+    fi
+
+    if [ "$ENV" == "k8s" ]; then
+        echo $(kubectl get routingrule -o json | jq -r .items[0].spec.$FIELD)
+	return 0
+    fi
+
+    echo "ENV is not set.  Exiting...."
+    exit 1
+}


### PR DESCRIPTION
The helloworld tests are only run for examples automation
(make test.examples).  Re-enabling them to run for examples
using the k8s native routing rules.  The integration tests for
k8s will still be disabled until the bookinfo tests are updated.