### PR TITLE
bug fix: subset matching for tags if instances has more than one

### DIFF
--- a/cli/commands/traffic_start.go
+++ b/cli/commands/traffic_start.go
@@ -210,8 +210,10 @@ func (cmd *TrafficStartCommand) StartTraffic(serviceName string, version string,
 // IsServiceActive .
 func (cmd *TrafficStartCommand) IsServiceActive(serviceName, version string, instances []*api.ServiceInstance) bool {
 	for _, instance := range instances {
-		if version == strings.Join(instance.Tags, ", ") {
-			return true
+		for _, tag := range instance.Tags {
+			if version == tag {
+				return true
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
kubernetes adapter appends additional tags to service instance.

Example:

```
a8ctl-beta-linux traffic-start -s reviews -v version=v3
```

Should the traffic-start command only match services registered as `reviews:version=v3` or should it also match `reviews:version=v3,tag2=value2` ?
