### PR TITLE
updated envoy binary with outlier detection and circuit breaker fixes

### DIFF
--- a/testing/test-scripts/bookinfo-default-route-productpage.yaml
+++ b/testing/test-scripts/bookinfo-default-route-productpage.yaml
@@ -6,3 +6,11 @@ rules:
     backends:
     - tags:
       - version=v1
+      resilience:
+        max_connections: 1111
+        max_pending_requests: 222
+        max_requests: 222
+        sleep_window: 0.9
+        consecutive_errors: 9
+        detection_interval: 0.5
+        max_requests_per_connection: 1234

--- a/testing/test-scripts/bookinfo-default-route-productpage.yaml
+++ b/testing/test-scripts/bookinfo-default-route-productpage.yaml
@@ -7,10 +7,10 @@ rules:
     - tags:
       - version=v1
       resilience:
-        max_connections: 1111
-        max_pending_requests: 222
-        max_requests: 222
-        sleep_window: 0.9
-        consecutive_errors: 9
+        max_connections: 1000
+        max_pending_requests: 200
+        max_requests: 200
+        sleep_window: 2.5
+        consecutive_errors: 10
         detection_interval: 0.5
-        max_requests_per_connection: 1234
+        max_requests_per_connection: 1000


### PR DESCRIPTION
included a more verbose rule for productpage with all resilience fields set to ensure envoy accepts them in their schema